### PR TITLE
[Ch3925] CLI!

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-20.04, windows-2019]
+        os: [macos-10.15, ubuntu-20.04]
         go: ["1.17"]
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ vendor/
 
 # Vscode
 .vscode/
+
+coverage.txt
+bin/

--- a/cmd/terradoc/main.go
+++ b/cmd/terradoc/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/mineiros-io/terradoc/internal/parser/hclparser"
+	"github.com/mineiros-io/terradoc/internal/renderers/markdown"
+)
+
+func main() {
+	outputFile := flag.String("o", "", "Output file name")
+
+	flag.Parse()
+
+	r, rCloser, err := openInput(flag.Args()...)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading input: %s\n", err)
+
+		os.Exit(1)
+	}
+	defer rCloser()
+
+	def, err := hclparser.Parse(r, r.Name())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parsing document: %v", err)
+
+		os.Exit(1)
+	}
+
+	w, wCloser, err := getOutputWriter(*outputFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "creating writer: %s\n", err)
+
+		os.Exit(1)
+	}
+	defer wCloser()
+
+	err = markdown.Render(w, def)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parsing document: %v", err)
+
+		os.Exit(1)
+	}
+}
+
+func getOutputWriter(filename string) (io.Writer, func(), error) {
+	if filename == "" {
+		return os.Stdout, noopClose, nil
+	}
+
+	f, err := os.Create(filename)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	closer := func() {
+		if err := f.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "closing output stream: %v", err)
+		}
+	}
+
+	return f, closer, nil
+}
+
+func openInput(args ...string) (*os.File, func(), error) {
+	switch len(args) {
+	case 0:
+		return os.Stdin, noopClose, nil
+	case 1:
+		f, err := os.Open(args[0])
+		if err != nil {
+			return nil, nil, err
+		}
+
+		closer := func() {
+			if err := f.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "closing input stream: %v", err)
+			}
+		}
+
+		return f, closer, nil
+	default:
+		return nil, nil, fmt.Errorf("expects none or one input file but given %d", len(args))
+	}
+}
+
+func noopClose() {}

--- a/cmd/terradoc/main_test.go
+++ b/cmd/terradoc/main_test.go
@@ -1,0 +1,147 @@
+package main_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/mineiros-io/terradoc/test"
+)
+
+var (
+	binName                   = "terradoc"
+	inputFixtureName          = "input.tfdoc.hcl"
+	expectedOutputFixtureName = "output.md"
+)
+
+func TestMain(m *testing.M) {
+	fmt.Println("Building tool...")
+
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+
+	build := exec.Command("go", "build", "-o", binName)
+
+	err := build.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot build %q: %v", binName, err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Running tests...")
+
+	result := m.Run()
+
+	fmt.Println("Cleaning up...")
+
+	os.Remove(binName)
+
+	os.Exit(result)
+}
+
+func TestTerradocCLI(t *testing.T) {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// set up input file and content - TODO: structure this better
+	inputContent := test.ReadFixture(t, inputFixtureName)
+
+	inputFile, err := ioutil.TempFile("", "terradoc-input-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inputFile.Close()
+
+	_, err = inputFile.Write(inputContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPath := filepath.Join(dir, binName)
+
+	expectedOutput := test.ReadFixture(t, expectedOutputFixtureName)
+
+	t.Run("ReadFromFile", func(t *testing.T) {
+		cmd := exec.Command(cmdPath, inputFile.Name())
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(output, expectedOutput) {
+			t.Errorf("Expected:\n%q\nGot:\n%q", string(expectedOutput), string(output))
+		}
+	})
+
+	t.Run("ReadFromSTDIN", func(t *testing.T) {
+		cmd := exec.Command(cmdPath)
+
+		cmdStdIn, err := cmd.StdinPipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = io.WriteString(cmdStdIn, string(inputContent))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmdStdIn.Close()
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(output, expectedOutput) {
+			t.Errorf("Expected:\n%q\nGot:\n%q", string(expectedOutput), string(output))
+		}
+	})
+
+	t.Run("WriteToStdout", func(t *testing.T) {
+		cmd := exec.Command(cmdPath, inputFile.Name())
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(output, expectedOutput) {
+			t.Errorf("Expected:\n%q\nGot:\n%q", string(expectedOutput), string(output))
+		}
+	})
+
+	t.Run("WriteToFile", func(t *testing.T) {
+		f, err := ioutil.TempFile("", "terradoc-output-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+
+		cmd := exec.Command(cmdPath, "-o", f.Name(), inputFile.Name())
+
+		err = cmd.Run()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := ioutil.ReadAll(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(result, expectedOutput) {
+			t.Errorf("Expected:\n%q\nGot:\n%q", string(expectedOutput), string(result))
+		}
+	})
+}

--- a/internal/parser/hclparser/hclparser_test.go
+++ b/internal/parser/hclparser/hclparser_test.go
@@ -53,7 +53,8 @@ func TestParse(t *testing.T) {
 										Name: "beers",
 										Type: entities.Type{
 											TerraformType: entities.TerraformType{
-												Type: types.TerraformAny,
+												Type:       types.TerraformList,
+												NestedType: types.TerraformAny,
 											},
 											ReadmeType: "list(beer)",
 										},
@@ -111,7 +112,7 @@ func TestParse(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			assertEqualDefinitions(t, tt.want, definition)
+			assertEqualDefinitions(t, tt.want, definition) //
 		})
 	}
 }

--- a/internal/renderers/markdown/markdown_test.go
+++ b/internal/renderers/markdown/markdown_test.go
@@ -66,7 +66,7 @@ func TestRender(t *testing.T) {
 							{
 								Name: "members",
 								Type: entities.Type{
-									TerraformType: entities.TerraformType{Type: types.TerraformString},
+									TerraformType: entities.TerraformType{Type: types.TerraformSet, NestedType: types.TerraformString},
 								},
 								Description: "Identities that will be granted the privilege in role. Each entry can have one of the following values:\n  - `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account.\n  - `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account.\n  - `user:{emailid}`: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.\n  - `serviceAccount:{emailid}`: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.\n  - `group:{emailid}`: An email address that represents a Google group. For example, admins@example.com.\n  - `domain:{domain}`: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.\n",
 								// Description: fmt.Sprintf(`Identities that will be granted the privilege in role. Each entry can have one of the following values:
@@ -198,8 +198,6 @@ func TestRender(t *testing.T) {
 	want := string(bytes.TrimSpace(wantContent))
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Logf("GOTN: %q", got)
-		t.Logf("WANT: %q", want)
 		t.Errorf("Expected golden file to match result (-want +got):\n%s", diff)
 	}
 }

--- a/internal/renderers/markdown/writer.go
+++ b/internal/renderers/markdown/writer.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	templateName  = "README.md"
-	templatesPath = "templates/markdown/*"
+	templateName = "README.md"
 
 	sectionTemplateName         = "section"
 	variableTemplateName        = "variable"

--- a/internal/renderers/markdown/writer_test.go
+++ b/internal/renderers/markdown/writer_test.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	lineBreak = "\n"
-	indent    = " "
 )
 
 func TestWriteSection(t *testing.T) {

--- a/test/testdata/golden-input.tfdoc.hcl
+++ b/test/testdata/golden-input.tfdoc.hcl
@@ -36,7 +36,7 @@ section {
       }
 
       variable "members" {
-        type = string
+        type = set(string)
         default = []
         description = <<END
 Identities that will be granted the privilege in role. Each entry can have one of the following values:

--- a/test/testdata/golden-readme.md
+++ b/test/testdata/golden-readme.md
@@ -28,7 +28,7 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   The id of the secret.
 
-- **`members`**: *(Optional `string`)*
+- **`members`**: *(Optional `set`)*
 
   Identities that will be granted the privilege in role. Each entry can have one of the following values:
   - `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account.
@@ -106,3 +106,4 @@ See [variables.tf] and [examples/] for details and use-cases.
     - **`description`**: *(Optional `string`)*
 
       An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+

--- a/test/testdata/input.tfdoc.hcl
+++ b/test/testdata/input.tfdoc.hcl
@@ -17,7 +17,7 @@ section {
     description = "an excuse to mention alcohol"
 
     variable "beers" {
-      type        = any
+      type        = list(any)
       readme_type = "list(beer)"
 
       description = "a list of beers"

--- a/test/testdata/output.md
+++ b/test/testdata/output.md
@@ -1,0 +1,46 @@
+# root section
+
+i am the root section
+
+## sub section with no description
+
+- **`name`**: *(Optional `string`)*
+
+  describes the name of the last person who bothered to change this file
+
+  Default is `"nathan"`.
+
+## section of beers
+
+an excuse to mention alcohol
+
+- **`beers`**: *(**Required** `list(beer)`, Forces new resource)*
+
+  a list of beers
+
+  Default is `[]`.
+
+  Example:
+
+  ```terraform
+  beers = [{
+      abv  = 4.2
+      name = "guinness"
+      type = "stout"
+    }]
+  ```
+
+  `list(beer)` is a `list` of `any` with the following attributes:
+
+  - **`name`**: *(Optional `string`)*
+
+    the name of the beer
+
+  - **`type`**: *(Optional `string`, Forces new resource)*
+
+    the type of the beer
+
+  - **`abv`**: *(Optional `number`, Forces new resource)*
+
+    beer's alcohol by volume content
+


### PR DESCRIPTION
Adds the following command-line interface:

1) Read from file and write to STDOUT

```sh
terradoc input-file.tfdoc.hcl
```

2) Read from file and write to file

```sh
terradoc -o output.md input-file.tfdoc.hcl
```

3) Read from STDIN and write to STDOUT

```sh
cat input-file.tfdoc.hcl | terradoc
```

3) Read from STDIN and write to file

```sh
cat input-file.tfdoc.hcl | terradoc -o output.md
```