### PR TITLE
[ch4042] fix: parse `readme_type` as string instead of HCL

### DIFF
--- a/internal/parser/hclparser/hclattribute.go
+++ b/internal/parser/hclparser/hclattribute.go
@@ -1,13 +1,11 @@
 package hclparser
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
-	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/mineiros-io/terradoc/internal/entities"
 	"github.com/mineiros-io/terradoc/internal/types"
 	"github.com/zclconf/go-cty/cty"
@@ -80,26 +78,6 @@ func (a *hclAttribute) RawJSON() (json.RawMessage, error) {
 	}
 
 	return json.RawMessage(src), nil
-}
-
-func (a *hclAttribute) HCLString() (string, error) {
-	if a.isNil() {
-		return "", nil
-	}
-
-	val, diags := a.Expr.Value(nil)
-	if diags.HasErrors() {
-		return "", fmt.Errorf("could not fetch HCL value for %q: %v", a.Name, diags.Errs())
-	}
-
-	tk := hclwrite.TokensForValue(val)
-	// As the fetched attribute has the format `{ content }\n`,
-	// remove the extra characters to have only the HCL content
-
-	//TODO: refactor
-	bVal := bytes.TrimSpace(bytes.TrimSuffix(bytes.TrimPrefix(bytes.TrimSpace(tk.Bytes()), []byte("{")), []byte("}")))
-
-	return string(bVal), nil
 }
 
 func (a *hclAttribute) TerraformType() (entities.TerraformType, error) {

--- a/internal/parser/hclparser/hclattribute_test.go
+++ b/internal/parser/hclparser/hclattribute_test.go
@@ -234,38 +234,6 @@ func TestAttributeToTerraformTypeValidComplexType(t *testing.T) {
 	t.Skip("I'm not sure how tf I'll test this")
 }
 
-func TestAttributeToHCL(t *testing.T) {
-	t.Run("with valid HCL", func(t *testing.T) {
-		// a block like `readme_example = {values = [{key = "value"}]}`
-		// gets parsed into a cty object like the following
-		objVal := cty.ObjectVal(map[string]cty.Value{
-			"values": cty.ListVal([]cty.Value{
-				cty.ObjectVal(
-					map[string]cty.Value{
-						"key": cty.StringVal("value"),
-					},
-				),
-			}),
-		})
-		// we need to ensure indentation is maintained
-		wantVal := `values = [{
-    key = "value"
-  }]`
-
-		expr := hcltest.MockExprLiteral(objVal)
-		attr := &hclAttribute{&hcl.Attribute{Name: "hcl", Expr: expr}}
-
-		res, err := attr.HCLString()
-		if err != nil {
-			t.Fatalf("Expected no error. Got %q instead", err)
-		}
-
-		if res != wantVal {
-			t.Errorf("Expected result to be %q. Got %q instead", wantVal, res)
-		}
-	})
-}
-
 type fakeHCLExpression struct {
 	value cty.Value
 }

--- a/internal/parser/hclparser/hclparser.go
+++ b/internal/parser/hclparser/hclparser.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
@@ -218,11 +219,12 @@ func createVariableFromHCLAttributes(attrs hcl.Attributes, name string) (entitie
 	variable.ForcesRecreation = forcesRecreation
 
 	// readme example
-	readmeExample, err := getAttribute(attrs, readmeExampleAttributeName).HCLString()
+	readmeExample, err := getAttribute(attrs, readmeExampleAttributeName).String()
 	if err != nil {
 		return entities.Variable{}, err
 	}
-	variable.ReadmeExample = readmeExample
+	// remove trailing newline if readme example is a multiline string
+	variable.ReadmeExample = strings.Trim(readmeExample, "\n")
 
 	// type definition
 	typeDefinition, err := getType(attrs, name)
@@ -259,11 +261,12 @@ func createAttributeFromHCLAttributes(attrs hcl.Attributes, name string, level i
 	attribute.ForcesRecreation = forcesRecreation
 
 	// readme example
-	readmeExample, err := getAttribute(attrs, readmeExampleAttributeName).HCLString()
+	readmeExample, err := getAttribute(attrs, readmeExampleAttributeName).String()
 	if err != nil {
 		return entities.Attribute{}, err
 	}
-	attribute.ReadmeExample = readmeExample
+	// remove trailing newline if readme example is a multiline string
+	attribute.ReadmeExample = strings.Trim(readmeExample, "\n")
 
 	// type definition
 	typeDefinition, err := getType(attrs, name)

--- a/internal/renderers/markdown/markdown_test.go
+++ b/internal/renderers/markdown/markdown_test.go
@@ -45,7 +45,7 @@ func TestRender(t *testing.T) {
 										Description: "A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency.",
 										// BUG: this is not correct - google_network.network should not be a string
 										// but it fails right now
-										ReadmeExample: `module_depends_on = ["google_network.network"]`,
+										ReadmeExample: "module_depends_on = [\n  google_network.network\n]",
 									},
 								},
 							},
@@ -109,11 +109,8 @@ func TestRender(t *testing.T) {
 									},
 									ReadmeType: "list(policy_bindings)",
 								},
-								Description: "A list of IAM policy bindings.",
-								ReadmeExample: `policy_bindings = [{
-    members = ["user:member@example.com"]
-    role    = "roles/secretmanager.secretAccessor"
-  }]`,
+								Description:   "A list of IAM policy bindings.",
+								ReadmeExample: "policy_bindings = [{\n  members = [\"user:member@example.com\"]\n  role    = \"roles/secretmanager.secretAccessor\"\n}]",
 								Attributes: []entities.Attribute{
 									{
 										Level:    1,
@@ -143,11 +140,8 @@ func TestRender(t *testing.T) {
 											TerraformType: entities.TerraformType{Type: types.TerraformAny},
 											ReadmeType:    "object(condition)",
 										},
-										Description: "An IAM Condition for a given binding.",
-										ReadmeExample: `condition = {
-    expression = "request.time < timestamp(\"2022-01-01T00:00:00Z\")"
-    title      = "expires_after_2021_12_31"
-  }`,
+										Description:   "An IAM Condition for a given binding.",
+										ReadmeExample: "condition = {\n  expression = \"request.time < timestamp(\\\"2022-01-01T00:00:00Z\\\")\"\n  title      = \"expires_after_2021_12_31\"\n}",
 										Attributes: []entities.Attribute{
 											{
 												Level:    2,

--- a/test/testdata/golden-input.tfdoc.hcl
+++ b/test/testdata/golden-input.tfdoc.hcl
@@ -18,11 +18,11 @@ section {
         type = any
         readme_type = "list(dependencies)"
         description = "A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency."
-        readme_example = {
-          module_depends_on = [
-            "google_network.network"
-          ]
-        }
+        readme_example = <<END
+module_depends_on = [
+  google_network.network
+]
+END
       }
     }
 
@@ -69,13 +69,12 @@ END
         type = list(any)
         readme_type = "list(policy_bindings)"
         description = "A list of IAM policy bindings."
-        readme_example = {
-          policy_bindings = [{
-            role    = "roles/secretmanager.secretAccessor"
-            members = ["user:member@example.com"]
-          }]
-        }
-
+        readme_example = <<END
+policy_bindings = [{
+  role    = "roles/secretmanager.secretAccessor"
+  members = ["user:member@example.com"]
+}]
+END
 
         attribute "role" {
           description = "The role that should be applied."
@@ -94,12 +93,12 @@ END
           type = any
           readme_type = "object(condition)"
           description = "An IAM Condition for a given binding."
-          readme_example = {
-            condition = {
-              expression = "request.time < timestamp(\"2022-01-01T00:00:00Z\")"
-              title      = "expires_after_2021_12_31"
-            }
-          }
+          readme_example = <<END
+condition = {
+  expression = "request.time < timestamp(\"2022-01-01T00:00:00Z\")"
+  title      = "expires_after_2021_12_31"
+}
+END
 
           attribute "expression" {
             type = string

--- a/test/testdata/golden-readme.md
+++ b/test/testdata/golden-readme.md
@@ -19,7 +19,9 @@ See [variables.tf] and [examples/] for details and use-cases.
   Example:
 
   ```terraform
-  module_depends_on = ["google_network.network"]
+  module_depends_on = [
+    google_network.network
+  ]
   ```
 
 ### Main Resource Configuration
@@ -63,9 +65,9 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   ```terraform
   policy_bindings = [{
-      members = ["user:member@example.com"]
-      role    = "roles/secretmanager.secretAccessor"
-    }]
+    members = ["user:member@example.com"]
+    role    = "roles/secretmanager.secretAccessor"
+  }]
   ```
 
   `list(policy_bindings)` is a `list` of `any` with the following attributes:
@@ -88,9 +90,9 @@ See [variables.tf] and [examples/] for details and use-cases.
 
     ```terraform
     condition = {
-        expression = "request.time < timestamp(\"2022-01-01T00:00:00Z\")"
-        title      = "expires_after_2021_12_31"
-      }
+      expression = "request.time < timestamp(\"2022-01-01T00:00:00Z\")"
+      title      = "expires_after_2021_12_31"
+    }
     ```
 
     `object(condition)` is a `any` with the following attributes:
@@ -106,4 +108,3 @@ See [variables.tf] and [examples/] for details and use-cases.
     - **`description`**: *(Optional `string`)*
 
       An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
-

--- a/test/testdata/input.tfdoc.hcl
+++ b/test/testdata/input.tfdoc.hcl
@@ -27,15 +27,15 @@ section {
 
       forces_recreation = true
 
-      readme_example = {
-        beers = [
-          {
-            name = "guinness"
-            type = "stout"
-            abv = 4.2
-          }
-        ]
-      }
+      readme_example = <<END
+beers = [
+  {
+    name = "guinness"
+    type = "stout"
+    abv  = 4.2
+  }
+]
+END
 
       attribute "name" {
         type = string

--- a/test/testdata/output.md
+++ b/test/testdata/output.md
@@ -23,11 +23,13 @@ an excuse to mention alcohol
   Example:
 
   ```terraform
-  beers = [{
-      abv  = 4.2
+  beers = [
+    {
       name = "guinness"
       type = "stout"
-    }]
+      abv  = 4.2
+    }
+  ]
   ```
 
   `list(beer)` is a `list` of `any` with the following attributes:


### PR DESCRIPTION
Our initial target was to use the `readme_example` attributes in the input tfdoc file as HCL code, but the limitations imposed by the HCL library - the code could not refer to unassigned variables, for example - made this feature to be more complicated than expected. Thus, we decided to keep the readme example as multi-line HCL strings on the input file.

This PR changes the `readme_example` attribute definition from

```hcl
readme_example = {
  policy_bindings = [{
    role    = "roles/secretmanager.secretAccessor"
    members = ["user:member@example.com"]
  }]
}
```

to


```hcl
readme_example = <<END
policy_bindings = [{
  role    = "roles/secretmanager.secretAccessor"
  members = ["user:member@example.com"]
}]
END
```

This change made life so much easier! :smile: 