### PR TITLE
[ch4138] add references block

### DIFF
--- a/cmd/terradoc/main.go
+++ b/cmd/terradoc/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	err = markdown.Render(w, def)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "parsing document: %v", err)
+		fmt.Fprintf(os.Stderr, "rendering document: %v", err)
 
 		os.Exit(1)
 	}

--- a/internal/entities/definition.go
+++ b/internal/entities/definition.go
@@ -2,5 +2,8 @@ package entities
 
 // Definition represents a parsed source file.
 type Definition struct {
-	Sections []Section `json:"sections"` // Sections is a collection of sections defined in the source file.
+	// Sections is a collection of sections defined in the source file.
+	Sections []Section `json:"sections"`
+	// References is a collection of references defined in the source file.
+	References []Reference `json:"references"`
 }

--- a/internal/entities/reference.go
+++ b/internal/entities/reference.go
@@ -1,0 +1,7 @@
+package entities
+
+// Reference represents a `ref` block on the source document
+type Reference struct {
+	Name  string `json:"name"`  // Name is the identifier for the reference
+	Value string `json:"value"` // Value is the value that the reference holds
+}

--- a/internal/entities/section.go
+++ b/internal/entities/section.go
@@ -2,10 +2,10 @@ package entities
 
 // Section represents a `section` block from the input file.
 type Section struct {
-	// Title is the title of the section.
+	// Title is an optional title for the section.
 	Title string `json:"title"`
-	// Description is an optional section description.
-	Description string `json:"description,omitempty"`
+	// Content is an optional text content for the section.
+	Content string `json:"content,omitempty"`
 	// Variables is a collection of variable definitions contained in the section block.
 	Variables []Variable `json:"variables,omitempty"`
 	// SubSections is a collection of nested sections contained in the section block.

--- a/internal/parser/hclparser/attributes.go
+++ b/internal/parser/hclparser/attributes.go
@@ -1,0 +1,92 @@
+package hclparser
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/mineiros-io/terradoc/internal/entities"
+	"github.com/mineiros-io/terradoc/internal/parser/hclparser/hclschema"
+)
+
+func parseVariableAttributes(attributeBlocks []*hcl.Block) (attributes []entities.Attribute, err error) {
+	const variableAttributeLevel = 1
+
+	for _, attrBlk := range attributeBlocks {
+		attribute, err := parseAttribute(attrBlk, variableAttributeLevel)
+		if err != nil {
+			return nil, fmt.Errorf("parsing attributes: %s", err)
+		}
+
+		attributes = append(attributes, attribute)
+	}
+
+	return attributes, nil
+}
+
+func parseAttribute(attrBlock *hcl.Block, level int) (entities.Attribute, error) {
+	attrContent, diags := attrBlock.Body.Content(hclschema.AttributeSchema())
+	if diags.HasErrors() {
+		return entities.Attribute{}, fmt.Errorf("parsing attribute block: %v", diags.Errs())
+	}
+
+	if len(attrBlock.Labels) != 1 {
+		return entities.Attribute{}, fmt.Errorf("expected single 'name' label, got %v", attrBlock.Labels)
+	}
+
+	name := attrBlock.Labels[0]
+	attr, err := createAttributeFromHCLAttributes(attrContent.Attributes, name, level)
+	if err != nil {
+		return entities.Attribute{}, fmt.Errorf("parsing attribute: %s", err)
+	}
+
+	nestedAttributeLevel := level + 1
+	// attribute blocks have only `attribute` blocks
+	for _, blk := range attrContent.Blocks.OfType(attributeBlockName) {
+		nestedAttr, err := parseAttribute(blk, nestedAttributeLevel)
+		if err != nil {
+			return entities.Attribute{}, fmt.Errorf("parsing nested attribute: %s", err)
+		}
+
+		attr.Attributes = append(attr.Attributes, nestedAttr)
+	}
+
+	return attr, nil
+}
+
+func createAttributeFromHCLAttributes(attrs hcl.Attributes, name string, level int) (entities.Attribute, error) {
+	var err error
+
+	attr := entities.Attribute{Name: name, Level: level}
+
+	attr.Description, err = getAttribute(attrs, descriptionAttributeName).String()
+	if err != nil {
+		return entities.Attribute{}, err
+	}
+
+	attr.Required, err = getAttribute(attrs, requiredAttributeName).Bool()
+	if err != nil {
+		return entities.Attribute{}, err
+	}
+
+	attr.ForcesRecreation, err = getAttribute(attrs, forcesRecreationAttributeName).Bool()
+	if err != nil {
+		return entities.Attribute{}, err
+	}
+
+	attr.ReadmeExample, err = getAttribute(attrs, readmeExampleAttributeName).String()
+	if err != nil {
+		return entities.Attribute{}, err
+	}
+
+	attr.Type, err = getType(attrs, name)
+	if err != nil {
+		return entities.Attribute{}, err
+	}
+
+	attr.Default, err = getAttribute(attrs, defaultAttributeName).RawJSON()
+	if err != nil {
+		return entities.Attribute{}, err
+	}
+
+	return attr, nil
+}

--- a/internal/parser/hclparser/hclattribute.go
+++ b/internal/parser/hclparser/hclattribute.go
@@ -3,6 +3,7 @@ package hclparser
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
@@ -37,7 +38,7 @@ func (a *hclAttribute) String() (string, error) {
 		return "", fmt.Errorf("could not convert %q to string: %v", a.Name, err)
 	}
 
-	return strVal.AsString(), nil
+	return strings.TrimSpace(strVal.AsString()), nil
 }
 
 func (a *hclAttribute) Bool() (bool, error) {

--- a/internal/parser/hclparser/hclparser_test.go
+++ b/internal/parser/hclparser/hclparser_test.go
@@ -24,46 +24,21 @@ func TestParse(t *testing.T) {
 			want: entities.Definition{
 				Sections: []entities.Section{
 					{
-						Level:       1,
-						Title:       "root section",
-						Description: "i am the root section",
+						Content: `[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][mineiros-website]
+
+This is the root section content.
+
+Section contents support anything markdown and allow us to make references like this one: [mineiros-website]`,
 						SubSections: []entities.Section{
 							{
-								Level: 2,
-								Title: "sub section with no description",
-								Variables: []entities.Variable{
+								Level: 1,
+								Title: "sections with variables",
+
+								SubSections: []entities.Section{
 									{
-										Name: "name",
-										Type: entities.Type{
-											TerraformType: entities.TerraformType{
-												Type: types.TerraformString,
-											},
-										},
-										Description: "describes the name of the last person who bothered to change this file",
-										Default:     json.RawMessage("nathan"),
-									},
-								},
-							},
-							{
-								Level:       2,
-								Title:       "section of beers",
-								Description: "an excuse to mention alcohol",
-								Variables: []entities.Variable{
-									{
-										Name: "beers",
-										Type: entities.Type{
-											TerraformType: entities.TerraformType{
-												Type:       types.TerraformList,
-												NestedType: types.TerraformAny,
-											},
-											ReadmeType: "list(beer)",
-										},
-										Description:      "a list of beers",
-										Default:          json.RawMessage("[]"),
-										Required:         true,
-										ForcesRecreation: true,
-										ReadmeExample:    "",
-										Attributes: []entities.Attribute{
+										Level: 2,
+										Title: "example",
+										Variables: []entities.Variable{
 											{
 												Name: "name",
 												Type: entities.Type{
@@ -71,28 +46,62 @@ func TestParse(t *testing.T) {
 														Type: types.TerraformString,
 													},
 												},
-												Description:      "the name of the beer",
-												ForcesRecreation: false,
+												Description: "describes the name of the last person who bothered to change this file",
+												Default:     json.RawMessage("nathan"),
 											},
+										},
+									},
+									{
+										Level:   2,
+										Title:   "section of beers",
+										Content: "an excuse to mention alcohol",
+										Variables: []entities.Variable{
 											{
-												Name: "type",
+												Name: "beers",
 												Type: entities.Type{
 													TerraformType: entities.TerraformType{
-														Type: types.TerraformString,
+														Type:       types.TerraformList,
+														NestedType: types.TerraformAny,
+													},
+													ReadmeType: "list(beer)",
+												},
+												Description:      "a list of beers",
+												Default:          json.RawMessage("[]"),
+												Required:         true,
+												ForcesRecreation: true,
+												ReadmeExample:    "",
+												Attributes: []entities.Attribute{
+													{
+														Name: "name",
+														Type: entities.Type{
+															TerraformType: entities.TerraformType{
+																Type: types.TerraformString,
+															},
+														},
+														Description:      "the name of the beer",
+														ForcesRecreation: false,
+													},
+													{
+														Name: "type",
+														Type: entities.Type{
+															TerraformType: entities.TerraformType{
+																Type: types.TerraformString,
+															},
+														},
+														Description:      "the type of the beer",
+														ForcesRecreation: true,
+													},
+													{
+														Name: "abv",
+														Type: entities.Type{
+															TerraformType: entities.TerraformType{
+																Type: types.TerraformNumber,
+															},
+														},
+														Description:      "beer's alcohol by volume content",
+														ForcesRecreation: true,
 													},
 												},
-												Description:      "the type of the beer",
-												ForcesRecreation: true,
-											},
-											{
-												Name: "abv",
-												Type: entities.Type{
-													TerraformType: entities.TerraformType{
-														Type: types.TerraformNumber,
-													},
-												},
-												Description:      "beer's alcohol by volume content",
-												ForcesRecreation: true,
 											},
 										},
 									},
@@ -123,42 +132,6 @@ func TestParseInvalidContent(t *testing.T) {
 		wantErrorMsgContains string
 		content              string
 	}{
-		{
-			desc:                 "root section without title",
-			wantErrorMsgContains: `The argument "title" is required, but no definition was found.`,
-			content: `
-section {
-  section {
-    title = "sub section with no description"
-
-    variable "name" {
-      type        = string
-      description = "describes the name of the last person who bothered to change this file"
-      default     = "nathan"
-    }
-  }
-}
-
-`,
-		},
-		{
-			desc:                 "sub section without title",
-			wantErrorMsgContains: `The argument "title" is required, but no definition was found.`,
-			content: `
-section {
-  title = "test"
-
-  section {
-    variable "name" {
-      type        = string
-      description = "describes the name of the last person who bothered to change this file"
-      default     = "nathan"
-    }
-  }
-}
-
-`,
-		},
 		{
 			desc:                 "variable block without a label",
 			wantErrorMsgContains: "Missing name for variable; All variable blocks must have 1 labels (name).",
@@ -300,8 +273,8 @@ func assertSectionEquals(t *testing.T, want, got entities.Section) {
 		t.Errorf("Expected section title to be %q. Got %q instead", want.Title, got.Title)
 	}
 
-	if want.Description != got.Description {
-		t.Errorf("Expected section description to be %q. Got %q instead", want.Description, got.Description)
+	if want.Content != got.Content {
+		t.Errorf("Expected section content to be %q. Got %q instead", want.Content, got.Content)
 	}
 
 	if want.Level != got.Level {

--- a/internal/parser/hclparser/hclschema/hclschema.go
+++ b/internal/parser/hclparser/hclschema/hclschema.go
@@ -9,6 +9,32 @@ func RootSchema() *hcl.BodySchema {
 				Type:       "section",
 				LabelNames: []string{},
 			},
+			{
+				Type:       "references",
+				LabelNames: []string{},
+			},
+		},
+	}
+}
+
+func ReferencesSchema() *hcl.BodySchema {
+	return &hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{
+			{
+				Type:       "ref",
+				LabelNames: []string{"name"},
+			},
+		},
+	}
+}
+
+func RefSchema() *hcl.BodySchema {
+	return &hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{
+				Name:     "value",
+				Required: true,
+			},
 		},
 	}
 }
@@ -18,10 +44,10 @@ func SectionSchema() *hcl.BodySchema {
 		Attributes: []hcl.AttributeSchema{
 			{
 				Name:     "title",
-				Required: true,
+				Required: false,
 			},
 			{
-				Name:     "description",
+				Name:     "content",
 				Required: false,
 			},
 		},

--- a/internal/parser/hclparser/hclschema/hclschema_test.go
+++ b/internal/parser/hclparser/hclschema/hclschema_test.go
@@ -25,8 +25,8 @@ func TestSectionSchema(t *testing.T) {
 	s := hclschema.SectionSchema()
 
 	// schema attributes
-	assertHasAttribute(t, s, "title", true)
-	assertHasAttribute(t, s, "description", false)
+	assertHasAttribute(t, s, "title", false)
+	assertHasAttribute(t, s, "content", false)
 
 	// schema blocks
 	nestedSectionBlocks := getBlocks(s.Blocks, "section")

--- a/internal/parser/hclparser/references.go
+++ b/internal/parser/hclparser/references.go
@@ -1,0 +1,57 @@
+package hclparser
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/mineiros-io/terradoc/internal/entities"
+	"github.com/mineiros-io/terradoc/internal/parser/hclparser/hclschema"
+)
+
+func parseReferences(referencesBlocks []*hcl.Block) ([]entities.Reference, error) {
+	switch {
+	case len(referencesBlocks) == 0:
+		return nil, nil
+	case len(referencesBlocks) != 1:
+		return nil,
+			fmt.Errorf("parsing references: expected at most 1 `references` block but got %d instead", len(referencesBlocks))
+	}
+
+	referencesContent, diags := referencesBlocks[0].Body.Content(hclschema.ReferencesSchema())
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("parsing references: %v", diags.Errs())
+	}
+
+	return parseRefs(referencesContent.Blocks.OfType(refBlockName))
+}
+
+func parseRefs(refBlocks []*hcl.Block) (refs []entities.Reference, err error) {
+	for _, refBlock := range refBlocks {
+		ref, err := parseRef(refBlock)
+		if err != nil {
+			return nil, err
+		}
+
+		refs = append(refs, ref)
+	}
+
+	return refs, nil
+}
+
+func parseRef(refBlock *hcl.Block) (entities.Reference, error) {
+	// name
+	name := refBlock.Labels[0]
+
+	refContent, diags := refBlock.Body.Content(hclschema.RefSchema())
+	if diags.HasErrors() {
+		return entities.Reference{}, fmt.Errorf("parsing Terradoc `references`: %v", diags.Errs())
+	}
+
+	// value
+	value, err := getAttribute(refContent.Attributes, valueAttributeName).String()
+	if err != nil {
+		return entities.Reference{}, err
+	}
+
+	return entities.Reference{Name: name, Value: value}, nil
+}

--- a/internal/parser/hclparser/sections.go
+++ b/internal/parser/hclparser/sections.go
@@ -1,0 +1,78 @@
+package hclparser
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/mineiros-io/terradoc/internal/entities"
+	"github.com/mineiros-io/terradoc/internal/parser/hclparser/hclschema"
+)
+
+const (
+	rootSectionLevel = 0
+)
+
+func parseSections(sectionBlocks []*hcl.Block) (sections []entities.Section, err error) {
+	for _, sectionBlock := range sectionBlocks {
+		section, err := parseSection(sectionBlock, rootSectionLevel) // initial level
+		if err != nil {
+			return nil, fmt.Errorf("parsing sections: %s", err)
+		}
+
+		sections = append(sections, section)
+	}
+
+	return sections, nil
+}
+
+func parseSection(sectionBlock *hcl.Block, level int) (entities.Section, error) {
+	sectionContent, diags := sectionBlock.Body.Content(hclschema.SectionSchema())
+	if diags.HasErrors() {
+		return entities.Section{}, fmt.Errorf("parsing Terradoc section: %v", diags.Errs())
+	}
+
+	section, err := createSectionFromHCLAttributes(sectionContent.Attributes, level)
+	if err != nil {
+		return entities.Section{}, fmt.Errorf("parsing section: %s", err)
+	}
+
+	// parse `variable` blocks
+	variables, err := parseVariables(sectionContent.Blocks.OfType(variableBlockName))
+	if err != nil {
+		return entities.Section{}, fmt.Errorf("parsing section variable: %v", err)
+	}
+	section.Variables = variables
+
+	subSectionLevel := level + 1
+	// parse `section` blocks
+	for _, subSectionBlk := range sectionContent.Blocks.OfType(sectionBlockName) {
+		subSection, err := parseSection(subSectionBlk, subSectionLevel)
+		if err != nil {
+			return entities.Section{}, fmt.Errorf("parsing subsection: %s", err)
+		}
+
+		section.SubSections = append(section.SubSections, subSection)
+	}
+
+	return section, nil
+}
+
+func createSectionFromHCLAttributes(attrs hcl.Attributes, level int) (entities.Section, error) {
+	section := entities.Section{Level: level}
+
+	// title
+	title, err := getAttribute(attrs, titleAttributeName).String()
+	if err != nil {
+		return entities.Section{}, err
+	}
+	section.Title = title
+
+	// fetch section content
+	content, err := getAttribute(attrs, contentAttributeName).String()
+	if err != nil {
+		return entities.Section{}, err
+	}
+	section.Content = content
+
+	return section, nil
+}

--- a/internal/parser/hclparser/variables.go
+++ b/internal/parser/hclparser/variables.go
@@ -1,0 +1,88 @@
+package hclparser
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/mineiros-io/terradoc/internal/entities"
+	"github.com/mineiros-io/terradoc/internal/parser/hclparser/hclschema"
+)
+
+func parseVariables(variableBlocks []*hcl.Block) (variables []entities.Variable, err error) {
+	for _, varBlk := range variableBlocks {
+		variable, err := parseVariable(varBlk)
+		if err != nil {
+			return nil, fmt.Errorf("parsing variable: %s", err)
+		}
+
+		variables = append(variables, variable)
+	}
+
+	return variables, nil
+}
+
+func parseVariable(variableBlock *hcl.Block) (entities.Variable, error) {
+	if len(variableBlock.Labels) != 1 {
+		return entities.Variable{}, errors.New("variable block does not have a name")
+	}
+
+	variableContent, diags := variableBlock.Body.Content(hclschema.VariableSchema())
+	if diags.HasErrors() {
+		return entities.Variable{}, fmt.Errorf("parsing variable: %v", diags.Errs())
+	}
+
+	// variables have only the `name` label
+	name := variableBlock.Labels[0]
+	variable, err := createVariableFromHCLAttributes(variableContent.Attributes, name)
+	if err != nil {
+		return entities.Variable{}, fmt.Errorf("parsing variable: %s", err)
+	}
+
+	// variables have only `attribute` blocks
+	attributes, err := parseVariableAttributes(variableContent.Blocks.OfType(attributeBlockName))
+	if err != nil {
+		return entities.Variable{}, fmt.Errorf("parsing variable attributes: %s", err)
+	}
+	variable.Attributes = attributes
+
+	return variable, nil
+}
+
+func createVariableFromHCLAttributes(attrs hcl.Attributes, name string) (entities.Variable, error) {
+	var err error
+
+	variable := entities.Variable{Name: name}
+
+	variable.Description, err = getAttribute(attrs, descriptionAttributeName).String()
+	if err != nil {
+		return entities.Variable{}, err
+	}
+
+	variable.Default, err = getAttribute(attrs, defaultAttributeName).RawJSON()
+	if err != nil {
+		return entities.Variable{}, err
+	}
+
+	variable.Required, err = getAttribute(attrs, requiredAttributeName).Bool()
+	if err != nil {
+		return entities.Variable{}, err
+	}
+
+	variable.ForcesRecreation, err = getAttribute(attrs, forcesRecreationAttributeName).Bool()
+	if err != nil {
+		return entities.Variable{}, err
+	}
+
+	variable.ReadmeExample, err = getAttribute(attrs, readmeExampleAttributeName).String()
+	if err != nil {
+		return entities.Variable{}, err
+	}
+
+	variable.Type, err = getType(attrs, name)
+	if err != nil {
+		return entities.Variable{}, err
+	}
+
+	return variable, nil
+}

--- a/internal/renderers/markdown/markdown.go
+++ b/internal/renderers/markdown/markdown.go
@@ -12,5 +12,5 @@ func Render(writer io.Writer, definition entities.Definition) error {
 		return err
 	}
 
-	return mdWriter.writeSections(definition.Sections)
+	return mdWriter.writeDefinition(definition)
 }

--- a/internal/renderers/markdown/markdown_test.go
+++ b/internal/renderers/markdown/markdown_test.go
@@ -16,158 +16,263 @@ func TestRender(t *testing.T) {
 	definition := entities.Definition{
 		Sections: []entities.Section{
 			{
-				Title:       "Module Argument Reference",
-				Description: "See [variables.tf] and [examples/] for details and use-cases.",
-				Level:       1,
+				Level: 0,
+				Content: `[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][homepage]
+
+[![Terraform Version][badge-terraform]][releases-terraform]
+[![Google Provider Version][badge-tf-gcp]][releases-google-provider]
+[![Join Slack][badge-slack]][slack]`,
 				SubSections: []entities.Section{
 					{
-						Title: "Top-level Arguments",
-						Level: 2,
+						Level: 1,
+						Title: "terraform-google-secret-manager-iam",
+						Content: `A [Terraform](https://www.terraform.io) module to create a [Google Secret Manager IAM](https://cloud.google.com/secret-manager/docs/access-control) on [Google Cloud Services (GCP)](https://cloud.google.com/).
+
+**_This module supports Terraform version 1
+and is compatible with the Terraform Google Provider version 3._**
+
+This module is part of our Infrastructure as Code (IaC) framework
+that enables our users and customers to easily deploy and manage reusable,
+secure, and production-grade cloud infrastructure.
+
+- [Module Features](#module-features)
+- [Getting Started](#getting-started)
+- [Module Argument Reference](#module-argument-reference)
+  - [Top-level Arguments](#top-level-arguments)
+    - [Module Configuration](#module-configuration)
+    - [Main Resource Configuration](#main-resource-configuration)
+    - [Extended Resource Configuration](#extended-resource-configuration)
+- [Module Attributes Reference](#module-attributes-reference)
+- [External Documentation](#external-documentation)
+  - [Google Documentation](#google-documentation)
+  - [Terraform Google Provider Documentation](#terraform-google-provider-documentation)
+- [Module Versioning](#module-versioning)
+  - [Backwards compatibility in ` + "`0.0.z` and `0.y.z`" + ` version](#backwards-compatibility-in-00z-and-0yz-version)
+- [About Mineiros](#about-mineiros)
+- [Reporting Issues](#reporting-issues)
+- [Contributing](#contributing)
+- [Makefile Targets](#makefile-targets)
+- [License](#license)`,
 						SubSections: []entities.Section{
 							{
-								Title: "Module Configuration",
-								Level: 3,
-								Variables: []entities.Variable{
+								Level: 2,
+								Title: "Module Features",
+								Content: `This module implements the following terraform resources:
+
+- ` + "`google_secret_manager_secret_iam_binding`" + `
+- ` + "`google_secret_manager_secret_iam_member`" + `
+- ` + "`google_secret_manager_secret_iam_policy`",
+							},
+							{
+								Level: 2,
+								Title: "Getting Started",
+								Content: `Most basic usage just setting required arguments:
+
+` + "```hcl" + `
+module "terraform-google-secret-manager-iam" {
+  source = "github.com/mineiros-io/terraform-google-secret-manager-iam.git?ref=v0.1.0"
+
+  secret_id = google_secret_manager_secret.secret-basic.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  members   = ["user:admin@example.com"]
+}
+` + "```",
+							},
+							{
+								Level:   2,
+								Title:   "Module Argument Reference",
+								Content: "See [variables.tf] and [examples/] for details and use-cases.",
+								SubSections: []entities.Section{
 									{
-										Name: "module_enabled",
-										Type: entities.Type{
-											TerraformType: entities.TerraformType{Type: types.TerraformBool},
-										},
-										Description: "Specifies whether resources in the module will be created.",
-										Default:     []byte("true"),
-									},
-									{
-										Name: "module_depends_on",
-										Type: entities.Type{
-											TerraformType: entities.TerraformType{Type: types.TerraformList},
-											ReadmeType:    "list(dependencies)",
-										},
-										Description: "A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency.",
-										// BUG: this is not correct - google_network.network should not be a string
-										// but it fails right now
-										ReadmeExample: "module_depends_on = [\n  google_network.network\n]",
-									},
-								},
-							},
-						},
-					},
-					{
-						Level: 3,
-						Title: "Main Resource Configuration",
-						Variables: []entities.Variable{
-							{
-								Name: "secret_id",
-								Type: entities.Type{
-									TerraformType: entities.TerraformType{Type: types.TerraformString},
-								},
-								Description: "The id of the secret.",
-								Required:    true,
-							},
-							{
-								Name: "members",
-								Type: entities.Type{
-									TerraformType: entities.TerraformType{Type: types.TerraformSet, NestedType: types.TerraformString},
-								},
-								Description: "Identities that will be granted the privilege in role. Each entry can have one of the following values:\n  - `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account.\n  - `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account.\n  - `user:{emailid}`: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.\n  - `serviceAccount:{emailid}`: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.\n  - `group:{emailid}`: An email address that represents a Google group. For example, admins@example.com.\n  - `domain:{domain}`: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.\n",
-								// Description: fmt.Sprintf(`Identities that will be granted the privilege in role. Each entry can have one of the following values:
-								// - %s: A special identifier that represents anyone who is on the internet; with or without a Google account.
-								// - %s: A special identifier that represents anyone who is authenticated with a Google account or a service account.
-								// - %s: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
-								// - %s: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
-								// - %s: An email address that represents a Google group. For example, admins@example.com.
-								// - %s: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.`, "`allUsers`", "`allAuthenticatedUsers`", "`user:{emailid}`", "`serviceAccount:{emailid}`", "`group:{emailid}`", "`domain:{domain}`"),
-								Default: []byte("[]"),
-							},
-							{
-								Name: "role",
-								Type: entities.Type{
-									TerraformType: entities.TerraformType{Type: types.TerraformString},
-								},
-								Description: "The role that should be applied. Note that custom roles must be of the format `[projects|organizations]/{parent-name}/roles/{role-name}`.",
-							},
-							{
-								Name: "project",
-								Type: entities.Type{
-									TerraformType: entities.TerraformType{Type: types.TerraformString},
-								},
-								Description: "The resource name of the project the policy is attached to. Its format is `projects/{project_id}`.",
-							},
-							{
-								Name: "authoritative",
-								Type: entities.Type{
-									TerraformType: entities.TerraformType{Type: types.TerraformBool},
-								},
-								Description: "Whether to exclusively set (authoritative mode) or add (non-authoritative/additive mode) members to the role.",
-								Default:     []byte("true"),
-							},
-							{
-								Name: "policy_bindings",
-								Type: entities.Type{
-									TerraformType: entities.TerraformType{
-										Type:       types.TerraformList,
-										NestedType: types.TerraformAny,
-									},
-									ReadmeType: "list(policy_bindings)",
-								},
-								Description:   "A list of IAM policy bindings.",
-								ReadmeExample: "policy_bindings = [{\n  members = [\"user:member@example.com\"]\n  role    = \"roles/secretmanager.secretAccessor\"\n}]",
-								Attributes: []entities.Attribute{
-									{
-										Level:    1,
-										Name:     "role",
-										Required: true,
-										Type: entities.Type{
-											TerraformType: entities.TerraformType{Type: types.TerraformString},
-										},
-										Description: "The role that should be applied.",
-									},
-									{
-										Level:    1,
-										Name:     "members",
-										Required: true,
-										Type: entities.Type{
-											TerraformType: entities.TerraformType{Type: types.TerraformString},
-										},
-										Description: "Identities that will be granted the privilege in `role`.",
-										// BUG: this is not correct - var.members should not be a string
-										// but it fails otherwise
-										Default: []byte(`"var.members"`),
-									},
-									{
-										Level: 1,
-										Name:  "condition",
-										Type: entities.Type{
-											TerraformType: entities.TerraformType{Type: types.TerraformAny},
-											ReadmeType:    "object(condition)",
-										},
-										Description:   "An IAM Condition for a given binding.",
-										ReadmeExample: "condition = {\n  expression = \"request.time < timestamp(\\\"2022-01-01T00:00:00Z\\\")\"\n  title      = \"expires_after_2021_12_31\"\n}",
-										Attributes: []entities.Attribute{
+										Level: 3,
+										Title: "Top-level Arguments",
+										SubSections: []entities.Section{
 											{
-												Level:    2,
-												Name:     "expression",
-												Required: true,
-												Type: entities.Type{
-													TerraformType: entities.TerraformType{Type: types.TerraformString},
+												Title: "Module Configuration",
+												Level: 4,
+												Variables: []entities.Variable{
+													{
+														Name: "module_enabled",
+														Type: entities.Type{
+															TerraformType: entities.TerraformType{
+																Type: types.TerraformBool,
+															},
+														},
+														Description: "Specifies whether resources in the module will be created.",
+														Default:     []byte("true"),
+													},
+													{
+														Name: "module_depends_on",
+														Type: entities.Type{
+															ReadmeType: "list(dependencies)",
+															TerraformType: entities.TerraformType{
+																Type:       types.TerraformList,
+																NestedType: types.TerraformAny,
+															},
+														},
+														Description: "A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency.",
+														ReadmeExample: `module_depends_on = [
+  google_network.network
+]`,
+													},
 												},
-												Description: "Textual representation of an expression in Common Expression Language syntax.",
 											},
 											{
-												Level:    2,
-												Name:     "title",
-												Required: true,
-												Type: entities.Type{
-													TerraformType: entities.TerraformType{Type: types.TerraformString},
+												Level: 4,
+												Title: "Main Resource Configuration",
+												Variables: []entities.Variable{
+													{
+														Name:     "secret_id",
+														Required: true,
+														Type: entities.Type{
+															TerraformType: entities.TerraformType{
+																Type: types.TerraformString,
+															},
+														},
+														Description: "The id of the secret.",
+													},
+													{
+														Name: "members",
+														Type: entities.Type{
+															TerraformType: entities.TerraformType{
+																Type:       types.TerraformSet,
+																NestedType: types.TerraformString,
+															},
+														},
+														Default: []byte("[]"),
+														Description: `Identities that will be granted the privilege in role. Each entry can have one of the following values:
+  - ` + "`allUsers`" + `: A special identifier that represents anyone who is on the internet; with or without a Google account.
+  - ` + "`allAuthenticatedUsers`" + `: A special identifier that represents anyone who is authenticated with a Google account or a service account.
+  - ` + "`user:{emailid}`" + `: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
+  - ` + "`serviceAccount:{emailid}`" + `: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
+  - ` + "`group:{emailid}`" + `: An email address that represents a Google group. For example, admins@example.com.
+  - ` + "`domain:{domain}`" + `: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
+  - ` + "`projectOwner:projectid`" + `: Owners of the given project. For example, ` + "`projectOwner:my-example-project`" + `
+  - ` + "`projectEditor:projectid`" + `: Editors of the given project. For example, ` + "`projectEditor:my-example-project`" + `
+  - ` + "`projectViewer:projectid`" + `: Viewers of the given project. For example, ` + "`projectViewer:my-example-project`",
+													},
+													{
+														Name: "role",
+														Type: entities.Type{
+															TerraformType: entities.TerraformType{
+																Type: types.TerraformString,
+															},
+														},
+														Description: "The role that should be applied. Note that custom roles must be of the format `[projects|organizations]/{parent-name}/roles/{role-name}`.",
+													},
+													{
+														Name: "project",
+														Type: entities.Type{
+															TerraformType: entities.TerraformType{
+																Type: types.TerraformString,
+															},
+														},
+														Description: "The ID of the project in which the resource belongs. If it is not provided, the project will be parsed from the identifier of the parent resource. If no project is provided in the parent identifier and no project is specified, the provider project is used.",
+													},
+													{
+														Name: "authoritative",
+														Type: entities.Type{
+															TerraformType: entities.TerraformType{
+																Type: types.TerraformBool,
+															},
+														},
+														Default:     []byte("true"),
+														Description: "Whether to exclusively set (authoritative mode) or add (non-authoritative/additive mode) members to the role.",
+													},
+													{
+														Name: "policy_bindings",
+														Type: entities.Type{
+															ReadmeType: "list(policy_bindings)",
+															TerraformType: entities.TerraformType{
+																Type:       types.TerraformList,
+																NestedType: types.TerraformAny,
+															},
+														},
+														Description: "A list of IAM policy bindings.",
+														ReadmeExample: `policy_bindings = [{
+  role    = "roles/secretmanager.secretAccessor"
+  members = ["user:member@example.com"]
+}]`,
+														Attributes: []entities.Attribute{
+															{
+																Level:       1,
+																Name:        "role",
+																Description: "The role that should be applied.",
+																Required:    true,
+																Type: entities.Type{
+																	TerraformType: entities.TerraformType{
+																		Type: types.TerraformString,
+																	},
+																},
+															},
+															{
+																Level:       1,
+																Name:        "members",
+																Description: "Identities that will be granted the privilege in `role`.",
+																Type: entities.Type{
+																	TerraformType: entities.TerraformType{
+																		Type:       types.TerraformSet,
+																		NestedType: types.TerraformString,
+																	},
+																},
+																Default: []byte("var.members"),
+															},
+															{
+																Level:       1,
+																Name:        "condition",
+																Description: "An IAM Condition for a given binding.",
+																Type: entities.Type{
+																	ReadmeType: "object(condition)",
+																	TerraformType: entities.TerraformType{
+																		Type: types.TerraformAny,
+																	},
+																},
+																ReadmeExample: `condition = {
+  expression = "request.time < timestamp(\"2022-01-01T00:00:00Z\")"
+  title      = "expires_after_2021_12_31"
+}`,
+																Attributes: []entities.Attribute{
+																	{
+																		Level:       2,
+																		Name:        "expression",
+																		Description: "Textual representation of an expression in Common Expression Language syntax.",
+																		Required:    true,
+																		Type: entities.Type{
+																			TerraformType: entities.TerraformType{
+																				Type: types.TerraformString,
+																			},
+																		},
+																	},
+																	{
+																		Level:       2,
+																		Name:        "title",
+																		Description: "A title for the expression, i.e. a short string describing its purpose.",
+																		Required:    true,
+																		Type: entities.Type{
+																			TerraformType: entities.TerraformType{
+																				Type: types.TerraformString,
+																			},
+																		},
+																	},
+																	{
+																		Level:       2,
+																		Name:        "description",
+																		Description: "An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.",
+																		Type: entities.Type{
+																			TerraformType: entities.TerraformType{
+																				Type: types.TerraformString,
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
 												},
-												Description: "A title for the expression, i.e. a short string describing its purpose.",
 											},
 											{
-												Level: 2,
-												Name:  "description",
-												Type: entities.Type{
-													TerraformType: entities.TerraformType{Type: types.TerraformString},
-												},
-												Description: "An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.",
+												Level: 4,
+												Title: "Extended Resource Configuration",
 											},
 										},
 									},
@@ -176,6 +281,194 @@ func TestRender(t *testing.T) {
 						},
 					},
 				},
+			},
+			{
+				Level: 2,
+				Title: "Module Attributes Reference",
+				Content: `The following attributes are exported in the outputs of the module:
+
+- **` + "`module_enabled`" + `**
+
+  Whether this module is enabled.
+
+- **` + "`iam`" + `**
+
+  All attributes of the created ` + "`iam_binding` or `iam_member` or `iam_policy`" + ` resource according to the mode.`,
+			},
+			{
+				Level: 2,
+				Title: "External Documentation",
+				SubSections: []entities.Section{
+					{
+						Level: 3,
+						Title: "Google Documentation",
+						Content: `- Secret Manager: <https://cloud.google.com/secret-manager/docs>
+- Secret Manager Access Control: <https://cloud.google.com/secret-manager/docs/access-control>`,
+					},
+					{
+						Level: 3,
+						Title: "Terraform Google Provider Documentation",
+						Content: `- <https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret>
+- <https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam>`,
+					},
+				},
+			},
+			{
+				Level: 2,
+				Title: "Module Versioning",
+				Content: `This Module follows the principles of [Semantic Versioning (SemVer)].
+
+Given a version number ` + "`MAJOR.MINOR.PATCH`" + `, we increment the:
+
+1. ` + "`MAJOR`" + ` version when we make incompatible changes,
+2. ` + "`MINOR`" + ` version when we add functionality in a backwards compatible manner, and
+3. ` + "`PATCH`" + ` version when we make backwards compatible bug fixes.`,
+				SubSections: []entities.Section{
+					{
+						Level: 3,
+						Title: "Backwards compatibility in `0.0.z` and `0.y.z` version",
+						Content: `- Backwards compatibility in versions ` + "`0.0.z`" + ` is **not guaranteed** when ` + "`z`" + ` is increased. (Initial development)
+- Backwards compatibility in versions ` + "`0.y.z`" + ` is **not guaranteed** when ` + "`y`" + ` is increased. (Pre-release)`,
+					},
+				},
+			},
+			{
+				Level: 2,
+				Title: "About Mineiros",
+				Content: `[Mineiros][homepage] is a remote-first company headquartered in Berlin, Germany
+that solves development, automation and security challenges in cloud infrastructure.
+
+Our vision is to massively reduce time and overhead for teams to manage and
+deploy production-grade and secure cloud infrastructure.
+
+We offer commercial support for all of our modules and encourage you to reach out
+if you have any questions or need help. Feel free to email us at [hello@mineiros.io] or join our
+[Community Slack channel][slack].`,
+			},
+			{
+				Level:   2,
+				Title:   "Reporting Issues",
+				Content: "We use GitHub [Issues] to track community reported issues and missing features.",
+			},
+			{
+				Level: 2,
+				Title: "Contributing",
+				Content: `Contributions are always encouraged and welcome! For the process of accepting changes, we use
+[Pull Requests]. If you'd like more information, please see our [Contribution Guidelines].`,
+			},
+			{
+				Level: 2,
+				Title: "Makefile Targets",
+				Content: `This repository comes with a handy [Makefile].
+Run ` + "`make help`" + ` to see details on each available target.`,
+			},
+			{
+				Level: 2,
+				Title: "License",
+				Content: `[![license][badge-license]][apache20]
+
+This module is licensed under the Apache License Version 2.0, January 2004.
+Please see [LICENSE] for full details.
+
+Copyright &copy; 2020-2021 [Mineiros GmbH][homepage]`,
+			},
+		},
+		References: []entities.Reference{
+			{
+				Name:  "homepage",
+				Value: "https://mineiros.io/?ref=terraform-google-secret-manager-iam",
+			},
+			{
+				Name:  "hello@mineiros.io",
+				Value: "mailto:hello@mineiros.io",
+			},
+			{
+				Name:  "badge-build",
+				Value: "https://github.com/mineiros-io/terraform-google-secret-manager-iam/workflows/Tests/badge.svg",
+			},
+			{
+				Name:  "badge-semver",
+				Value: "https://img.shields.io/github/v/tag/mineiros-io/terraform-google-secret-manager-iam.svg?label=latest&sort=semver",
+			},
+			{
+				Name:  "badge-license",
+				Value: "https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg",
+			},
+			{
+				Name:  "badge-terraform",
+				Value: "https://img.shields.io/badge/Terraform-1.x-623CE4.svg?logo=terraform",
+			},
+			{
+				Name:  "badge-slack",
+				Value: "https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack",
+			},
+			{
+				Name:  "build-status",
+				Value: "https://github.com/mineiros-io/terraform-google-secret-manager-iam/actions",
+			},
+			{
+				Name:  "releases-github",
+				Value: "https://github.com/mineiros-io/erraform-google-secret-manager-iam/releases",
+			},
+			{
+				Name:  "releases-terraform",
+				Value: "https://github.com/hashicorp/terraform/releases",
+			},
+			{
+				Name:  "badge-tf-gcp",
+				Value: "https://img.shields.io/badge/google-3.x-1A73E8.svg?logo=terraform",
+			},
+			{
+				Name:  "releases-google-provider",
+				Value: "https://github.com/terraform-providers/terraform-provider-google/releases",
+			},
+			{
+				Name:  "apache20",
+				Value: "https://opensource.org/licenses/Apache-2.0",
+			},
+			{
+				Name:  "slack",
+				Value: "https://mineiros.io/slack",
+			},
+			{
+				Name:  "terraform",
+				Value: "https://www.terraform.io",
+			},
+			{
+				Name:  "gcp",
+				Value: "https://cloud.google.com/",
+			},
+			{
+				Name:  "semantic versioning (semver)",
+				Value: "https://semver.org/",
+			},
+			{
+				Name:  "variables.tf",
+				Value: "https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/variables.tf",
+			},
+			{
+				Name:  "examples/",
+				Value: "https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/examples",
+			},
+			{
+				Name:  "issues",
+				Value: "https://github.com/mineiros-io/terraform-google-secret-manager-iam/issues",
+			},
+			{
+				Name:  "license",
+				Value: "https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/LICENSE",
+			},
+			{
+				Name:  "makefile",
+				Value: "https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/Makefile",
+			},
+			{
+				Name:  "pull requests",
+				Value: "https://github.com/mineiros-io/terraform-google-secret-manager-iam/pulls",
+			},
+			{
+				Name:  "contribution guidelines",
+				Value: "https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/CONTRIBUTING.md",
 			},
 		},
 	}

--- a/internal/renderers/markdown/writer.go
+++ b/internal/renderers/markdown/writer.go
@@ -13,6 +13,7 @@ const (
 	templateName = "README.md"
 
 	sectionTemplateName         = "section"
+	referencesTemplateName      = "references"
 	variableTemplateName        = "variable"
 	attributeTemplateName       = "attribute"
 	typeDescriptionTemplateName = "typeDescription"
@@ -34,6 +35,22 @@ func newMarkdownWriter(writer io.Writer) (*markdownWriter, error) {
 	}
 
 	return &markdownWriter{writer: writer, templ: t}, nil
+}
+
+func (mw *markdownWriter) writeDefinition(definition entities.Definition) error {
+	if err := mw.writeSections(definition.Sections); err != nil {
+		return err
+	}
+
+	return mw.writeReferences(definition.References)
+}
+
+func (mw *markdownWriter) writeReferences(references []entities.Reference) error {
+	if len(references) == 0 {
+		return nil
+	}
+
+	return mw.writeTemplate(referencesTemplateName, references)
 }
 
 func (mw *markdownWriter) writeSections(sections []entities.Section) error {

--- a/internal/renderers/markdown/writer_test.go
+++ b/internal/renderers/markdown/writer_test.go
@@ -25,9 +25,9 @@ func TestWriteSection(t *testing.T) {
 		{
 			desc: "with description and 4 levels",
 			section: entities.Section{
-				Level:       4,
-				Title:       "I AM THE TITLE!",
-				Description: "Dude, this is a section",
+				Level:   4,
+				Title:   "I AM THE TITLE!",
+				Content: "Dude, this is a section",
 			},
 			want: mdSection{
 				heading:     "#### I AM THE TITLE!",
@@ -287,7 +287,7 @@ func assertMarkdownHasVariable(t *testing.T, buf *bytes.Buffer, md mdVariable) {
 
 	if md.readmeExample != "" {
 		// TODO: what's a better way of checking that indentation is right?
-		want += fmt.Sprintf("\n  Example:\n\n  ```terraform\n  %s  \n  ```\n", md.readmeExample)
+		want += fmt.Sprintf("\n  Example:\n\n  ```hcl\n  %s  \n  ```\n", md.readmeExample)
 	}
 
 	want += "\n"
@@ -311,7 +311,7 @@ func assertMarkdownHasAttribute(t *testing.T, buf *bytes.Buffer, md mdAttribute)
 	}
 
 	if md.readmeExample != "" {
-		want += fmt.Sprintf("\n  Example:\n\n  ```terraform\n  %s\n \n ```\n", md.readmeExample)
+		want += fmt.Sprintf("\n  Example:\n\n  ```hcl\n  %s\n \n ```\n", md.readmeExample)
 	}
 
 	want += lineBreak

--- a/templates/markdown/attribute.md
+++ b/templates/markdown/attribute.md
@@ -1,4 +1,4 @@
-{{define "attribute"}}{{indent (multiply .Level 2) "-"}} **`{{.Name}}`**: *({{if .Required}}**Required**{{else}}Optional{{end}} `{{if .Type.ReadmeType}}{{.Type.ReadmeType}}{{else}}{{.Type.TerraformType.Type}}{{end}}`{{if .ForcesRecreation}}, Forces new resource{{end}})*
+{{define "attribute"}}{{indent (multiply .Level 2) "-"}} **`{{.Name}}`**: *({{if .Required}}**Required**{{else}}Optional{{end}} `{{template "variableType" .Type}}`{{if .ForcesRecreation}}, Forces new resource{{end}})*
 
 {{- if .Description}}{{- newline}}{{indent (getIndent .Level) .Description}}{{end}}
 
@@ -6,6 +6,6 @@
 
 {{- if .ReadmeExample}}{{- newline}}{{indent (getIndent .Level) "Example:"}}
 
-{{printf "```terraform\n%s\n```" .ReadmeExample | indent (getIndent .Level)}}{{end -}}
+{{printf "```hcl\n%s\n```" .ReadmeExample | indent (getIndent .Level)}}{{end -}}
 {{- newline -}}
 {{end}}

--- a/templates/markdown/references.md
+++ b/templates/markdown/references.md
@@ -1,0 +1,6 @@
+{{define "references"}}
+<!-- References -->
+{{range . }}
+[{{.Name}}]: {{.Value}}{{end}}
+
+{{end}}

--- a/templates/markdown/section.md
+++ b/templates/markdown/section.md
@@ -1,5 +1,3 @@
-{{- define "section"}}
-{{- repeat "#" .Level}} {{.Title -}}
-
-{{if .Description}}{{newline}}{{.Description}}{{end}}{{- newline -}}
-{{end -}}
+{{define "section"}}{{if .Title}}{{repeat "#" .Level}} {{.Title}}{{- end -}}
+{{- newline -}}
+{{if .Content}}{{.Content}}{{- newline -}}{{end}}{{- end -}}

--- a/templates/markdown/variable.md
+++ b/templates/markdown/variable.md
@@ -1,4 +1,4 @@
-{{define "variable"}}- **`{{.Name}}`**: *({{if .Required}}**Required**{{else}}Optional{{end}} `{{if .Type.ReadmeType}}{{.Type.ReadmeType}}{{else}}{{.Type.TerraformType.Type}}{{end}}`{{if .ForcesRecreation}}, Forces new resource{{end}})*
+{{define "variable"}}- **`{{.Name}}`**: *({{if .Required}}**Required**{{else}}Optional{{end}} `{{template "variableType" .Type}}`{{if .ForcesRecreation}}, Forces new resource{{end}})*
 
 {{- if .Description}}{{- newline}}  {{print .Description}}{{- end}}
 
@@ -6,6 +6,6 @@
 
 {{- if .ReadmeExample}}{{- newline}}  Example:
 
-{{printf "```terraform\n%s\n```" .ReadmeExample | indent 2}}{{end -}}
+{{printf "```hcl\n%s\n```" .ReadmeExample | indent 2}}{{end -}}
 {{- newline -}}
 {{end}}

--- a/templates/markdown/variableType.md
+++ b/templates/markdown/variableType.md
@@ -1,0 +1,11 @@
+{{- define "variableType" -}}
+{{- if .ReadmeType -}}
+  {{- .ReadmeType -}}
+{{- else -}}
+    {{- if .TerraformType.HasNestedType -}}
+        {{- .TerraformType.Type -}}({{.TerraformType.NestedType}})
+    {{- else -}}
+        {{- .TerraformType.Type -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/test/testdata/golden-input.tfdoc.hcl
+++ b/test/testdata/golden-input.tfdoc.hcl
@@ -1,44 +1,113 @@
 section {
-  title = "Module Argument Reference"
-  description = "See [variables.tf] and [examples/] for details and use-cases."
+  content = <<END
+[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][homepage]
+
+[![Terraform Version][badge-terraform]][releases-terraform]
+[![Google Provider Version][badge-tf-gcp]][releases-google-provider]
+[![Join Slack][badge-slack]][slack]
+END
 
   section {
-    title = "Top-level Arguments"
+    title = "terraform-google-secret-manager-iam"
+    content = <<END
+A [Terraform](https://www.terraform.io) module to create a [Google Secret Manager IAM](https://cloud.google.com/secret-manager/docs/access-control) on [Google Cloud Services (GCP)](https://cloud.google.com/).
+
+**_This module supports Terraform version 1
+and is compatible with the Terraform Google Provider version 3._**
+
+This module is part of our Infrastructure as Code (IaC) framework
+that enables our users and customers to easily deploy and manage reusable,
+secure, and production-grade cloud infrastructure.
+
+- [Module Features](#module-features)
+- [Getting Started](#getting-started)
+- [Module Argument Reference](#module-argument-reference)
+  - [Top-level Arguments](#top-level-arguments)
+    - [Module Configuration](#module-configuration)
+    - [Main Resource Configuration](#main-resource-configuration)
+    - [Extended Resource Configuration](#extended-resource-configuration)
+- [Module Attributes Reference](#module-attributes-reference)
+- [External Documentation](#external-documentation)
+  - [Google Documentation](#google-documentation)
+  - [Terraform Google Provider Documentation](#terraform-google-provider-documentation)
+- [Module Versioning](#module-versioning)
+  - [Backwards compatibility in `0.0.z` and `0.y.z` version](#backwards-compatibility-in-00z-and-0yz-version)
+- [About Mineiros](#about-mineiros)
+- [Reporting Issues](#reporting-issues)
+- [Contributing](#contributing)
+- [Makefile Targets](#makefile-targets)
+- [License](#license)
+END
 
     section {
-      title = "Module Configuration"
+      title = "Module Features"
+      content = <<END
+This module implements the following terraform resources:
 
-      variable "module_enabled" {
-        type = bool
-        description = "Specifies whether resources in the module will be created."
-        default = true
-      }
+- `google_secret_manager_secret_iam_binding`
+- `google_secret_manager_secret_iam_member`
+- `google_secret_manager_secret_iam_policy`
+END
+    }
 
-      variable "module_depends_on" {
-        type = any
-        readme_type = "list(dependencies)"
-        description = "A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency."
-        readme_example = <<END
+    section {
+      title = "Getting Started"
+      content = <<END
+Most basic usage just setting required arguments:
+
+```hcl
+module "terraform-google-secret-manager-iam" {
+  source = "github.com/mineiros-io/terraform-google-secret-manager-iam.git?ref=v0.1.0"
+
+  secret_id = google_secret_manager_secret.secret-basic.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  members   = ["user:admin@example.com"]
+}
+```
+END
+    }
+
+    section {
+      title = "Module Argument Reference"
+      content = "See [variables.tf] and [examples/] for details and use-cases."
+
+      section {
+        title = "Top-level Arguments"
+
+        section {
+          title = "Module Configuration"
+
+          variable "module_enabled" {
+            type = bool
+            description = "Specifies whether resources in the module will be created."
+            default = true
+          }
+
+          variable "module_depends_on" {
+            type = list(any)
+            readme_type = "list(dependencies)"
+            description = "A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency."
+            readme_example = <<END
 module_depends_on = [
   google_network.network
 ]
 END
-      }
-    }
+          }
+        }
 
-    section {
-      title = "Main Resource Configuration"
+        section {
+          title = "Main Resource Configuration"
 
-      variable "secret_id" {
-        required = true
-        type = string
-        description = "The id of the secret."
-      }
+          variable "secret_id" {
+            required = true
+            type = string
+            description = "The id of the secret."
+          }
 
-      variable "members" {
-        type = set(string)
-        default = []
-        description = <<END
+          variable "members" {
+            type = set(string)
+            default = []
+            description = <<END
 Identities that will be granted the privilege in role. Each entry can have one of the following values:
   - `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account.
   - `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account.
@@ -47,77 +116,267 @@ Identities that will be granted the privilege in role. Each entry can have one o
   - `group:{emailid}`: An email address that represents a Google group. For example, admins@example.com.
   - `domain:{domain}`: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 END
-      }
+          }
 
-      variable "role" {
-        type = string
-        description = "The role that should be applied. Note that custom roles must be of the format `[projects|organizations]/{parent-name}/roles/{role-name}`."
-      }
+          variable "role" {
+            type = string
+            description = "The role that should be applied. Note that custom roles must be of the format `[projects|organizations]/{parent-name}/roles/{role-name}`."
+          }
 
-      variable "project" {
-        type = string
-        description = "The resource name of the project the policy is attached to. Its format is `projects/{project_id}`."
-      }
+          variable "project" {
+            type = string
+            description = "The resource name of the project the policy is attached to. Its format is `projects/{project_id}`."
+          }
 
-      variable "authoritative" {
-        description = "Whether to exclusively set (authoritative mode) or add (non-authoritative/additive mode) members to the role."
-        type = bool
-        default = true
-      }
+          variable "authoritative" {
+            description = "Whether to exclusively set (authoritative mode) or add (non-authoritative/additive mode) members to the role."
+            type = bool
+            default = true
+          }
 
-      variable "policy_bindings" {
-        type = list(any)
-        readme_type = "list(policy_bindings)"
-        description = "A list of IAM policy bindings."
-        readme_example = <<END
+          variable "policy_bindings" {
+            type = list(any)
+            readme_type = "list(policy_bindings)"
+            description = "A list of IAM policy bindings."
+            readme_example = <<END
 policy_bindings = [{
   role    = "roles/secretmanager.secretAccessor"
   members = ["user:member@example.com"]
 }]
 END
 
-        attribute "role" {
-          description = "The role that should be applied."
-          required = true
-          type = string
-        }
+            attribute "role" {
+              description = "The role that should be applied."
+              required = true
+              type = string
+            }
 
-        attribute "members" {
-          required = true
-          type = string
-          default = "var.members"
-          description = "Identities that will be granted the privilege in `role`."
-        }
+            attribute "members" {
+              required = true
+              type = string
+              default = "var.members"
+              description = "Identities that will be granted the privilege in `role`."
+            }
 
-        attribute "condition" {
-          type = any
-          readme_type = "object(condition)"
-          description = "An IAM Condition for a given binding."
-          readme_example = <<END
+            attribute "condition" {
+              type = any
+              readme_type = "object(condition)"
+              description = "An IAM Condition for a given binding."
+              readme_example = <<END
 condition = {
   expression = "request.time < timestamp(\"2022-01-01T00:00:00Z\")"
   title      = "expires_after_2021_12_31"
 }
 END
 
-          attribute "expression" {
-            type = string
-            required = true
-            description = "Textual representation of an expression in Common Expression Language syntax."
-          }
+              attribute "expression" {
+                type = string
+                required = true
+                description = "Textual representation of an expression in Common Expression Language syntax."
+              }
 
-          attribute "title" {
-            type = string
-            required = true
-            description = "A title for the expression, i.e. a short string describing its purpose."
-          }
+              attribute "title" {
+                type = string
+                required = true
+                description = "A title for the expression, i.e. a short string describing its purpose."
+              }
 
-          attribute "description" {
-            type = string
-            description = "An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI."
+              attribute "description" {
+                type = string
+                description = "An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI."
+              }
+            }
           }
         }
       }
     }
+  }
+
+  section {
+    title = "External Documentation"
+
+    section {
+      title = "Google Documentation"
+      content = <<END
+- Secret Manager: <https://cloud.google.com/secret-manager/docs>
+- Secret Manager Access Control: <https://cloud.google.com/secret-manager/docs/access-control>
+END
+
+    }
+
+    section {
+      title = "Terraform Google Provider Documentation"
+      content = <<END
+- <https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret>
+- <https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam>
+END
+    }
+  }
+
+  section {
+    title = "Module Versioning"
+    content = <<END
+This Module follows the principles of [Semantic Versioning (SemVer)].
+
+Given a version number `MAJOR.MINOR.PATCH`, we increment the:
+
+1. `MAJOR` version when we make incompatible changes,
+2. `MINOR` version when we add functionality in a backwards compatible manner, and
+3. `PATCH` version when we make backwards compatible bug fixes.
+END
+
+    section {
+      title = "Backwards compatibility in `0.0.z` and `0.y.z` version"
+      content = <<END
+- Backwards compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased. (Initial development)
+- Backwards compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased. (Pre-release)
+END
+    }
+  }
+
+  section {
+    title = "About Mineiros"
+    content = <<END
+[Mineiros][homepage] is a remote-first company headquartered in Berlin, Germany
+that solves development, automation and security challenges in cloud infrastructure.
+
+Our vision is to massively reduce time and overhead for teams to manage and
+deploy production-grade and secure cloud infrastructure.
+
+We offer commercial support for all of our modules and encourage you to reach out
+if you have any questions or need help. Feel free to email us at [hello@mineiros.io] or join our
+[Community Slack channel][slack].
+END
+  }
+
+  section {
+    title = "Reporting Issues"
+    content = "We use GitHub [Issues] to track community reported issues and missing features."
+  }
+
+  section {
+    title = "Contributing"
+    content = <<END
+Contributions are always encouraged and welcome! For the process of accepting changes, we use
+[Pull Requests]. If you'd like more information, please see our [Contribution Guidelines].
+END
+  }
+
+  section {
+    title = "Makefile Targets"
+    content = <<END
+This repository comes with a handy [Makefile].
+Run `make help` to see details on each available target.
+END
+  }
+
+  section {
+    title = "License"
+    content = <<END
+[![license][badge-license]][apache20]
+
+This module is licensed under the Apache License Version 2.0, January 2004.
+Please see [LICENSE] for full details.
+
+Copyright &copy; 2020-2021 [Mineiros GmbH][homepage]
+END
+  }
+}
+
+references {
+  ref "homepage" {
+    value = "https://mineiros.io/?ref=terraform-google-secret-manager-iam"
+  }
+
+  ref "hello@mineiros.io" {
+    value = "mailto:hello@mineiros.io"
+  }
+
+  ref "badge-build" {
+    value = "https://github.com/mineiros-io/terraform-google-secret-manager-iam/workflows/Tests/badge.svg"
+  }
+
+  ref "badge-semver" {
+    value = "https://img.shields.io/github/v/tag/mineiros-io/terraform-google-secret-manager-iam.svg?label=latest&sort=semver"
+  }
+
+  ref "badge-license" {
+    value = "https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg"
+  }
+
+  ref "badge-terraform" {
+    value = "https://img.shields.io/badge/Terraform-1.x-623CE4.svg?logo=terraform"
+  }
+
+  ref "badge-slack" {
+    value = "https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack"
+  }
+
+  ref "build-status" {
+    value = "https://github.com/mineiros-io/terraform-google-secret-manager-iam/actions"
+  }
+
+  ref "releases-github" {
+    value = "https://github.com/mineiros-io/erraform-google-secret-manager-iam/releases"
+  }
+
+  ref "releases-terraform" {
+    value = "https://github.com/hashicorp/terraform/releases"
+  }
+
+  ref "badge-tf-gcp" {
+    value = "https://img.shields.io/badge/google-3.x-1A73E8.svg?logo=terraform"
+  }
+
+  ref "releases-google-provider" {
+    value = "https://github.com/terraform-providers/terraform-provider-google/releases"
+  }
+
+  ref "apache20" {
+    value = "https://opensource.org/licenses/Apache-2.0"
+  }
+
+  ref "slack" {
+    value = "https://mineiros.io/slack"
+  }
+
+  ref "terraform" {
+    value = "https://www.terraform.io"
+  }
+
+  ref "gcp" {
+    value = "https://cloud.google.com/"
+  }
+
+  ref "semantic versioning (semver)" {
+    value = "https://semver.org/"
+  }
+
+  ref "variables.tf" {
+    value = "https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/variables.tf"
+  }
+
+  ref "examples/" {
+    value = "https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/examples"
+  }
+
+  ref "issues" {
+    value = "https://github.com/mineiros-io/terraform-google-secret-manager-iam/issues"
+  }
+
+  ref "license" {
+    value = "https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/LICENSE"
+  }
+
+  ref "makefile" {
+    value = "https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/Makefile"
+  }
+
+  ref "pull requests" {
+    value = "https://github.com/mineiros-io/terraform-google-secret-manager-iam/pulls"
+  }
+
+  ref "contribution guidelines" {
+    value = "https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/CONTRIBUTING.md"
   }
 }

--- a/test/testdata/golden-readme.md
+++ b/test/testdata/golden-readme.md
@@ -1,10 +1,68 @@
-# Module Argument Reference
+[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][homepage]
+
+[![Terraform Version][badge-terraform]][releases-terraform]
+[![Google Provider Version][badge-tf-gcp]][releases-google-provider]
+[![Join Slack][badge-slack]][slack]
+
+# terraform-google-secret-manager-iam
+
+A [Terraform](https://www.terraform.io) module to create a [Google Secret Manager IAM](https://cloud.google.com/secret-manager/docs/access-control) on [Google Cloud Services (GCP)](https://cloud.google.com/).
+
+**_This module supports Terraform version 1
+and is compatible with the Terraform Google Provider version 3._**
+
+This module is part of our Infrastructure as Code (IaC) framework
+that enables our users and customers to easily deploy and manage reusable,
+secure, and production-grade cloud infrastructure.
+
+- [Module Features](#module-features)
+- [Getting Started](#getting-started)
+- [Module Argument Reference](#module-argument-reference)
+  - [Top-level Arguments](#top-level-arguments)
+    - [Module Configuration](#module-configuration)
+    - [Main Resource Configuration](#main-resource-configuration)
+    - [Extended Resource Configuration](#extended-resource-configuration)
+- [Module Attributes Reference](#module-attributes-reference)
+- [External Documentation](#external-documentation)
+  - [Google Documentation](#google-documentation)
+  - [Terraform Google Provider Documentation](#terraform-google-provider-documentation)
+- [Module Versioning](#module-versioning)
+  - [Backwards compatibility in `0.0.z` and `0.y.z` version](#backwards-compatibility-in-00z-and-0yz-version)
+- [About Mineiros](#about-mineiros)
+- [Reporting Issues](#reporting-issues)
+- [Contributing](#contributing)
+- [Makefile Targets](#makefile-targets)
+- [License](#license)
+
+## Module Features
+
+This module implements the following terraform resources:
+
+- `google_secret_manager_secret_iam_binding`
+- `google_secret_manager_secret_iam_member`
+- `google_secret_manager_secret_iam_policy`
+
+## Getting Started
+
+Most basic usage just setting required arguments:
+
+```hcl
+module "terraform-google-secret-manager-iam" {
+  source = "github.com/mineiros-io/terraform-google-secret-manager-iam.git?ref=v0.1.0"
+
+  secret_id = google_secret_manager_secret.secret-basic.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  members   = ["user:admin@example.com"]
+}
+```
+
+## Module Argument Reference
 
 See [variables.tf] and [examples/] for details and use-cases.
 
-## Top-level Arguments
+### Top-level Arguments
 
-### Module Configuration
+#### Module Configuration
 
 - **`module_enabled`**: *(Optional `bool`)*
 
@@ -18,19 +76,19 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   Example:
 
-  ```terraform
+  ```hcl
   module_depends_on = [
     google_network.network
   ]
   ```
 
-### Main Resource Configuration
+#### Main Resource Configuration
 
 - **`secret_id`**: *(**Required** `string`)*
 
   The id of the secret.
 
-- **`members`**: *(Optional `set`)*
+- **`members`**: *(Optional `set(string)`)*
 
   Identities that will be granted the privilege in role. Each entry can have one of the following values:
   - `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account.
@@ -39,7 +97,9 @@ See [variables.tf] and [examples/] for details and use-cases.
   - `serviceAccount:{emailid}`: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   - `group:{emailid}`: An email address that represents a Google group. For example, admins@example.com.
   - `domain:{domain}`: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
-
+  - `projectOwner:projectid`: Owners of the given project. For example, `projectOwner:my-example-project`
+  - `projectEditor:projectid`: Editors of the given project. For example, `projectEditor:my-example-project`
+  - `projectViewer:projectid`: Viewers of the given project. For example, `projectViewer:my-example-project`
 
   Default is `[]`.
 
@@ -49,7 +109,7 @@ See [variables.tf] and [examples/] for details and use-cases.
 
 - **`project`**: *(Optional `string`)*
 
-  The resource name of the project the policy is attached to. Its format is `projects/{project_id}`.
+  The ID of the project in which the resource belongs. If it is not provided, the project will be parsed from the identifier of the parent resource. If no project is provided in the parent identifier and no project is specified, the provider project is used.
 
 - **`authoritative`**: *(Optional `bool`)*
 
@@ -63,10 +123,10 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   Example:
 
-  ```terraform
+  ```hcl
   policy_bindings = [{
-    members = ["user:member@example.com"]
     role    = "roles/secretmanager.secretAccessor"
+    members = ["user:member@example.com"]
   }]
   ```
 
@@ -76,11 +136,11 @@ See [variables.tf] and [examples/] for details and use-cases.
 
     The role that should be applied.
 
-  - **`members`**: *(**Required** `string`)*
+  - **`members`**: *(Optional `set(string)`)*
 
     Identities that will be granted the privilege in `role`.
 
-    Default is `"var.members"`.
+    Default is `var.members`.
 
   - **`condition`**: *(Optional `object(condition)`)*
 
@@ -88,7 +148,7 @@ See [variables.tf] and [examples/] for details and use-cases.
 
     Example:
 
-    ```terraform
+    ```hcl
     condition = {
       expression = "request.time < timestamp(\"2022-01-01T00:00:00Z\")"
       title      = "expires_after_2021_12_31"
@@ -108,3 +168,108 @@ See [variables.tf] and [examples/] for details and use-cases.
     - **`description`**: *(Optional `string`)*
 
       An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+
+#### Extended Resource Configuration
+
+## Module Attributes Reference
+
+The following attributes are exported in the outputs of the module:
+
+- **`module_enabled`**
+
+  Whether this module is enabled.
+
+- **`iam`**
+
+  All attributes of the created `iam_binding` or `iam_member` or `iam_policy` resource according to the mode.
+
+## External Documentation
+
+### Google Documentation
+
+- Secret Manager: <https://cloud.google.com/secret-manager/docs>
+- Secret Manager Access Control: <https://cloud.google.com/secret-manager/docs/access-control>
+
+### Terraform Google Provider Documentation
+
+- <https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret>
+- <https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam>
+
+## Module Versioning
+
+This Module follows the principles of [Semantic Versioning (SemVer)].
+
+Given a version number `MAJOR.MINOR.PATCH`, we increment the:
+
+1. `MAJOR` version when we make incompatible changes,
+2. `MINOR` version when we add functionality in a backwards compatible manner, and
+3. `PATCH` version when we make backwards compatible bug fixes.
+
+### Backwards compatibility in `0.0.z` and `0.y.z` version
+
+- Backwards compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased. (Initial development)
+- Backwards compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased. (Pre-release)
+
+## About Mineiros
+
+[Mineiros][homepage] is a remote-first company headquartered in Berlin, Germany
+that solves development, automation and security challenges in cloud infrastructure.
+
+Our vision is to massively reduce time and overhead for teams to manage and
+deploy production-grade and secure cloud infrastructure.
+
+We offer commercial support for all of our modules and encourage you to reach out
+if you have any questions or need help. Feel free to email us at [hello@mineiros.io] or join our
+[Community Slack channel][slack].
+
+## Reporting Issues
+
+We use GitHub [Issues] to track community reported issues and missing features.
+
+## Contributing
+
+Contributions are always encouraged and welcome! For the process of accepting changes, we use
+[Pull Requests]. If you'd like more information, please see our [Contribution Guidelines].
+
+## Makefile Targets
+
+This repository comes with a handy [Makefile].
+Run `make help` to see details on each available target.
+
+## License
+
+[![license][badge-license]][apache20]
+
+This module is licensed under the Apache License Version 2.0, January 2004.
+Please see [LICENSE] for full details.
+
+Copyright &copy; 2020-2021 [Mineiros GmbH][homepage]
+
+
+<!-- References -->
+
+[homepage]: https://mineiros.io/?ref=terraform-google-secret-manager-iam
+[hello@mineiros.io]: mailto:hello@mineiros.io
+[badge-build]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/workflows/Tests/badge.svg
+[badge-semver]: https://img.shields.io/github/v/tag/mineiros-io/terraform-google-secret-manager-iam.svg?label=latest&sort=semver
+[badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
+[badge-terraform]: https://img.shields.io/badge/Terraform-1.x-623CE4.svg?logo=terraform
+[badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
+[build-status]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/actions
+[releases-github]: https://github.com/mineiros-io/erraform-google-secret-manager-iam/releases
+[releases-terraform]: https://github.com/hashicorp/terraform/releases
+[badge-tf-gcp]: https://img.shields.io/badge/google-3.x-1A73E8.svg?logo=terraform
+[releases-google-provider]: https://github.com/terraform-providers/terraform-provider-google/releases
+[apache20]: https://opensource.org/licenses/Apache-2.0
+[slack]: https://mineiros.io/slack
+[terraform]: https://www.terraform.io
+[gcp]: https://cloud.google.com/
+[semantic versioning (semver)]: https://semver.org/
+[variables.tf]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/variables.tf
+[examples/]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/examples
+[issues]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/issues
+[license]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/LICENSE
+[makefile]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/Makefile
+[pull requests]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/pulls
+[contribution guidelines]: https://github.com/mineiros-io/terraform-google-secret-manager-iam/blob/main/CONTRIBUTING.md
+

--- a/test/testdata/input.tfdoc.hcl
+++ b/test/testdata/input.tfdoc.hcl
@@ -1,33 +1,41 @@
 section {
-  title       = "root section"
-  description = "i am the root section"
+  content = <<END
+[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][mineiros-website]
+
+This is the root section content.
+
+Section contents support anything markdown and allow us to make references like this one: [mineiros-website]
+END
 
   section {
-    title = "sub section with no description"
+    title = "sections with variables"
 
-    variable "name" {
-      type        = string
-      description = "describes the name of the last person who bothered to change this file"
-      default     = "nathan"
+    section {
+      title = "example"
+
+      variable "name" {
+        type        = string
+        description = "describes the name of the last person who bothered to change this file"
+        default     = "nathan"
+      }
     }
-  }
 
-  section {
-    title = "section of beers"
-    description = "an excuse to mention alcohol"
+    section {
+      title = "section of beers"
+      content = "an excuse to mention alcohol"
 
-    variable "beers" {
-      type        = list(any)
-      readme_type = "list(beer)"
+      variable "beers" {
+        type        = list(any)
+        readme_type = "list(beer)"
 
-      description = "a list of beers"
-      default     = []
+        description = "a list of beers"
+        default     = []
 
-      required = true
+        required = true
 
-      forces_recreation = true
+        forces_recreation = true
 
-      readme_example = <<END
+        readme_example = <<END
 beers = [
   {
     name = "guinness"
@@ -37,27 +45,34 @@ beers = [
 ]
 END
 
-      attribute "name" {
-        type = string
+        attribute "name" {
+          type = string
 
-        description = "the name of the beer"
-      }
+          description = "the name of the beer"
+        }
 
-      attribute "type" {
-        type = string
+        attribute "type" {
+          type = string
 
-        description = "the type of the beer"
+          description = "the type of the beer"
 
-        forces_recreation = true
-      }
+          forces_recreation = true
+        }
 
-      attribute "abv" {
-        type = number
+        attribute "abv" {
+          type = number
 
-        description = "beer's alcohol by volume content"
+          description = "beer's alcohol by volume content"
 
-        forces_recreation = true
+          forces_recreation = true
+        }
       }
     }
+  }
+}
+
+references {
+  ref "mineiros-website" {
+    value = "https://www.mineiros.io"
   }
 }

--- a/test/testdata/output.md
+++ b/test/testdata/output.md
@@ -1,8 +1,14 @@
-# root section
 
-i am the root section
 
-## sub section with no description
+[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][mineiros-website]
+
+This is the root section content.
+
+Section contents support anything markdown and allow us to make references like this one: [mineiros-website]
+
+# sections with variables
+
+## example
 
 - **`name`**: *(Optional `string`)*
 
@@ -22,7 +28,7 @@ an excuse to mention alcohol
 
   Example:
 
-  ```terraform
+  ```hcl
   beers = [
     {
       name = "guinness"
@@ -45,4 +51,9 @@ an excuse to mention alcohol
   - **`abv`**: *(Optional `number`, Forces new resource)*
 
     beer's alcohol by volume content
+
+
+<!-- References -->
+
+[mineiros-website]: https://www.mineiros.io
 


### PR DESCRIPTION
- adds a `references` block to terradoc file definition
- sets section `title` attribute as optional
- renames section `description` attribute to `content`


given an input file https://github.com/mineiros-io/terradoc/blob/c7ea9ee87e9953b70da38a517e8025c460f042fe/test/testdata/golden-input.tfdoc.hcl

generates https://github.com/mineiros-io/terradoc/blob/c7ea9ee87e9953b70da38a517e8025c460f042fe/test/testdata/golden-readme.md