### PR TITLE
[ch4139] header block

### DIFF
--- a/internal/entities/definition.go
+++ b/internal/entities/definition.go
@@ -2,8 +2,25 @@ package entities
 
 // Definition represents a parsed source file.
 type Definition struct {
+	// Header is the header section block from the source file
+	Header Header
 	// Sections is a collection of sections defined in the source file.
 	Sections []Section `json:"sections"`
 	// References is a collection of references defined in the source file.
 	References []Reference `json:"references"`
+}
+
+// Header represents the `header` block on the parsed source file
+type Header struct {
+	Image  string  `json:"image"`  // Image is the image url to be displayed on the header
+	URL    string  `json:"url"`    // URL is the target url for the image
+	Badges []Badge `json:"badges"` // Badges is a collection of Badge entities
+}
+
+// Badge represents a `badge` block on the parsed source file
+type Badge struct {
+	Image string `json:"image"` // Image is the badge's image url
+	URL   string `json:"url"`   // URL is the target url for the badge
+	Text  string `json:"text"`  // Text is the text label for the badge
+	Name  string `json:"name"`  // Name is an identifier for the badge
 }

--- a/internal/parser/hclparser/hclparser.go
+++ b/internal/parser/hclparser/hclparser.go
@@ -21,12 +21,17 @@ const (
 	forcesRecreationAttributeName = "forces_recreation"
 	readmeExampleAttributeName    = "readme_example"
 	valueAttributeName            = "value"
+	imageAttributeName            = "image"
+	urlAttributeName              = "url"
+	textAttributeName             = "text"
 
 	sectionBlockName    = "section"
 	variableBlockName   = "variable"
 	attributeBlockName  = "attribute"
 	referencesBlockName = "references"
 	refBlockName        = "ref"
+	headerBlockName     = "header"
+	badgeBlockName      = "badge"
 )
 
 // Parse reads the content of a io.Reader and returns a Definition entity from its parsed values
@@ -58,6 +63,14 @@ func parseDefinition(f *hcl.File) (entities.Definition, error) {
 		return entities.Definition{}, fmt.Errorf("parsing Terradoc definition: %v", diags.Errs())
 	}
 
+	// header
+	header, err := parseHeader(definitionContent.Blocks.OfType(headerBlockName))
+	if err != nil {
+		return entities.Definition{}, fmt.Errorf("parsing header: %v", err)
+	}
+	def.Header = header
+
+	// sections
 	sections, err := parseSections(definitionContent.Blocks.OfType(sectionBlockName))
 	if err != nil {
 		return entities.Definition{}, err

--- a/internal/parser/hclparser/hclparser_test.go
+++ b/internal/parser/hclparser/hclparser_test.go
@@ -22,21 +22,25 @@ func TestParse(t *testing.T) {
 			desc:      "with a valid input",
 			inputFile: "input.tfdoc.hcl",
 			want: entities.Definition{
+				Header: entities.Header{
+					Image: "https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg",
+					URL:   "https://www.mineiros.io",
+				},
 				Sections: []entities.Section{
 					{
-						Content: `[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][mineiros-website]
-
-This is the root section content.
+						Level: 1,
+						Title: "root section",
+						Content: `This is the root section content.
 
 Section contents support anything markdown and allow us to make references like this one: [mineiros-website]`,
 						SubSections: []entities.Section{
 							{
-								Level: 1,
+								Level: 2,
 								Title: "sections with variables",
 
 								SubSections: []entities.Section{
 									{
-										Level: 2,
+										Level: 3,
 										Title: "example",
 										Variables: []entities.Variable{
 											{
@@ -52,7 +56,7 @@ Section contents support anything markdown and allow us to make references like 
 										},
 									},
 									{
-										Level:   2,
+										Level:   3,
 										Title:   "section of beers",
 										Content: "an excuse to mention alcohol",
 										Variables: []entities.Variable{
@@ -229,7 +233,33 @@ section {
 func assertEqualDefinitions(t *testing.T, want, got entities.Definition) {
 	t.Helper()
 
+	assertEqualHeader(t, want.Header, got.Header)
 	assertEqualSections(t, want.Sections, got.Sections)
+}
+
+func assertEqualHeader(t *testing.T, want, got entities.Header) {
+	t.Helper()
+
+	if want.Image != got.Image {
+		t.Errorf("Expected header image to be %q but got %q instead", want.Image, got.Image)
+	}
+
+	if want.URL != got.URL {
+		t.Errorf("Expected header url to be %q but got %q instead", want.URL, got.URL)
+	}
+
+	assertEqualBadges(t, want.Badges, got.Badges)
+
+}
+
+func assertEqualBadges(t *testing.T, got, want []entities.Badge) {
+	t.Helper()
+
+	if len(want) != len(got) {
+		t.Errorf("Expected header url to have %d badges but got %d instead", len(want), len(got))
+	}
+
+	// TODO: assert that badges are equivalents
 }
 
 func assertEqualSections(t *testing.T, want, got []entities.Section) {

--- a/internal/parser/hclparser/hclschema/hclschema.go
+++ b/internal/parser/hclparser/hclschema/hclschema.go
@@ -6,12 +6,56 @@ func RootSchema() *hcl.BodySchema {
 	return &hcl.BodySchema{
 		Blocks: []hcl.BlockHeaderSchema{
 			{
+				Type:       "header",
+				LabelNames: []string{},
+			},
+			{
 				Type:       "section",
 				LabelNames: []string{},
 			},
 			{
 				Type:       "references",
 				LabelNames: []string{},
+			},
+		},
+	}
+}
+
+func HeaderSchema() *hcl.BodySchema {
+	return &hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{
+				Name:     "image",
+				Required: false,
+			},
+			{
+				Name:     "url",
+				Required: false,
+			},
+		},
+		Blocks: []hcl.BlockHeaderSchema{
+			{
+				Type:       "badge",
+				LabelNames: []string{"name"},
+			},
+		},
+	}
+}
+
+func BadgeSchema() *hcl.BodySchema {
+	return &hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{
+				Name:     "image",
+				Required: true,
+			},
+			{
+				Name:     "url",
+				Required: true,
+			},
+			{
+				Name:     "text",
+				Required: true,
 			},
 		},
 	}

--- a/internal/parser/hclparser/header_parser.go
+++ b/internal/parser/hclparser/header_parser.go
@@ -1,0 +1,100 @@
+package hclparser
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/mineiros-io/terradoc/internal/entities"
+	"github.com/mineiros-io/terradoc/internal/parser/hclparser/hclschema"
+)
+
+func parseHeader(headerBlocks []*hcl.Block) (entities.Header, error) {
+	switch {
+	case len(headerBlocks) == 0:
+		return entities.Header{}, nil
+	case len(headerBlocks) > 1:
+		return entities.Header{}, fmt.Errorf("parsing Terradoc header: expected 1 but documenta has %d header blocks", len(headerBlocks))
+	}
+
+	headerBlock := headerBlocks[0]
+
+	headerContent, diags := headerBlock.Body.Content(hclschema.HeaderSchema())
+	if diags.HasErrors() {
+		return entities.Header{}, fmt.Errorf("parsing Terradoc header: %v", diags.Errs())
+	}
+
+	header, err := createHeaderFromHCLAttributes(headerContent.Attributes)
+	if err != nil {
+		return entities.Header{}, fmt.Errorf("parsing header: %s", err)
+	}
+
+	// parse `badge` blocks
+	for _, badgeBlk := range headerContent.Blocks.OfType(badgeBlockName) {
+		badge, err := parseBadge(badgeBlk)
+		if err != nil {
+			return entities.Header{}, fmt.Errorf("parsing header badge: %s", err)
+		}
+
+		header.Badges = append(header.Badges, badge)
+	}
+
+	return header, nil
+}
+
+func parseBadge(badgeBlock *hcl.Block) (entities.Badge, error) {
+	name := badgeBlock.Labels[0]
+
+	badgeContent, diags := badgeBlock.Body.Content(hclschema.BadgeSchema())
+	if diags.HasErrors() {
+		return entities.Badge{}, fmt.Errorf("parsing badge: %v", diags.Errs())
+	}
+
+	return createBadgeFromHCLAttributes(badgeContent.Attributes, name)
+}
+
+func createHeaderFromHCLAttributes(attrs hcl.Attributes) (entities.Header, error) {
+	header := entities.Header{}
+
+	// image
+	image, err := getAttribute(attrs, imageAttributeName).String()
+	if err != nil {
+		return entities.Header{}, err
+	}
+	header.Image = image
+
+	// url
+	url, err := getAttribute(attrs, urlAttributeName).String()
+	if err != nil {
+		return entities.Header{}, err
+	}
+	header.URL = url
+
+	return header, nil
+}
+
+func createBadgeFromHCLAttributes(attrs hcl.Attributes, name string) (entities.Badge, error) {
+	badge := entities.Badge{Name: name}
+
+	// image
+	image, err := getAttribute(attrs, imageAttributeName).String()
+	if err != nil {
+		return entities.Badge{}, err
+	}
+	badge.Image = image
+
+	// url
+	url, err := getAttribute(attrs, urlAttributeName).String()
+	if err != nil {
+		return entities.Badge{}, err
+	}
+	badge.URL = url
+
+	// url
+	text, err := getAttribute(attrs, textAttributeName).String()
+	if err != nil {
+		return entities.Badge{}, err
+	}
+	badge.Text = text
+
+	return badge, nil
+}

--- a/internal/parser/hclparser/sections.go
+++ b/internal/parser/hclparser/sections.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	rootSectionLevel = 0
+	rootSectionLevel = 1
 )
 
 func parseSections(sectionBlocks []*hcl.Block) (sections []entities.Section, err error) {

--- a/internal/renderers/markdown/markdown_test.go
+++ b/internal/renderers/markdown/markdown_test.go
@@ -14,19 +14,35 @@ import (
 
 func TestRender(t *testing.T) {
 	definition := entities.Definition{
+		Header: entities.Header{
+			Image: "https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg",
+			URL:   "https://mineiros.io/?ref=terraform-google-secret-manager-iam",
+			Badges: []entities.Badge{
+				{
+					Image: "https://img.shields.io/badge/Terraform-1.x-623CE4.svg?logo=terraform",
+					Text:  "Terraform Version",
+					Name:  "badge-terraform",
+					URL:   "https://github.com/hashicorp/terraform/releases",
+				},
+				{
+					Image: "https://img.shields.io/badge/google-3.x-1A73E8.svg?logo=terraform",
+					Text:  "Google Provider Version",
+					Name:  "badge-tf-gcp",
+					URL:   "https://github.com/terraform-providers/terraform-provider-google/releases",
+				},
+				{
+					Image: "https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack",
+					Text:  "Join Slack",
+					Name:  "badge-slack",
+					URL:   "https://mineiros.io/slack",
+				},
+			},
+		},
 		Sections: []entities.Section{
 			{
-				Level: 0,
-				Content: `[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][homepage]
-
-[![Terraform Version][badge-terraform]][releases-terraform]
-[![Google Provider Version][badge-tf-gcp]][releases-google-provider]
-[![Join Slack][badge-slack]][slack]`,
-				SubSections: []entities.Section{
-					{
-						Level: 1,
-						Title: "terraform-google-secret-manager-iam",
-						Content: `A [Terraform](https://www.terraform.io) module to create a [Google Secret Manager IAM](https://cloud.google.com/secret-manager/docs/access-control) on [Google Cloud Services (GCP)](https://cloud.google.com/).
+				Level: 1,
+				Title: "terraform-google-secret-manager-iam",
+				Content: `A [Terraform](https://www.terraform.io) module to create a [Google Secret Manager IAM](https://cloud.google.com/secret-manager/docs/access-control) on [Google Cloud Services (GCP)](https://cloud.google.com/).
 
 **_This module supports Terraform version 1
 and is compatible with the Terraform Google Provider version 3._**
@@ -53,20 +69,20 @@ secure, and production-grade cloud infrastructure.
 - [Contributing](#contributing)
 - [Makefile Targets](#makefile-targets)
 - [License](#license)`,
-						SubSections: []entities.Section{
-							{
-								Level: 2,
-								Title: "Module Features",
-								Content: `This module implements the following terraform resources:
+				SubSections: []entities.Section{
+					{
+						Level: 2,
+						Title: "Module Features",
+						Content: `This module implements the following terraform resources:
 
 - ` + "`google_secret_manager_secret_iam_binding`" + `
 - ` + "`google_secret_manager_secret_iam_member`" + `
 - ` + "`google_secret_manager_secret_iam_policy`",
-							},
-							{
-								Level: 2,
-								Title: "Getting Started",
-								Content: `Most basic usage just setting required arguments:
+					},
+					{
+						Level: 2,
+						Title: "Getting Started",
+						Content: `Most basic usage just setting required arguments:
 
 ` + "```hcl" + `
 module "terraform-google-secret-manager-iam" {
@@ -77,70 +93,70 @@ module "terraform-google-secret-manager-iam" {
   members   = ["user:admin@example.com"]
 }
 ` + "```",
-							},
+					},
+					{
+						Level:   2,
+						Title:   "Module Argument Reference",
+						Content: "See [variables.tf] and [examples/] for details and use-cases.",
+						SubSections: []entities.Section{
 							{
-								Level:   2,
-								Title:   "Module Argument Reference",
-								Content: "See [variables.tf] and [examples/] for details and use-cases.",
+								Level: 3,
+								Title: "Top-level Arguments",
 								SubSections: []entities.Section{
 									{
-										Level: 3,
-										Title: "Top-level Arguments",
-										SubSections: []entities.Section{
+										Title: "Module Configuration",
+										Level: 4,
+										Variables: []entities.Variable{
 											{
-												Title: "Module Configuration",
-												Level: 4,
-												Variables: []entities.Variable{
-													{
-														Name: "module_enabled",
-														Type: entities.Type{
-															TerraformType: entities.TerraformType{
-																Type: types.TerraformBool,
-															},
-														},
-														Description: "Specifies whether resources in the module will be created.",
-														Default:     []byte("true"),
-													},
-													{
-														Name: "module_depends_on",
-														Type: entities.Type{
-															ReadmeType: "list(dependencies)",
-															TerraformType: entities.TerraformType{
-																Type:       types.TerraformList,
-																NestedType: types.TerraformAny,
-															},
-														},
-														Description: "A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency.",
-														ReadmeExample: `module_depends_on = [
-  google_network.network
-]`,
+												Name: "module_enabled",
+												Type: entities.Type{
+													TerraformType: entities.TerraformType{
+														Type: types.TerraformBool,
 													},
 												},
+												Description: "Specifies whether resources in the module will be created.",
+												Default:     []byte("true"),
 											},
 											{
-												Level: 4,
-												Title: "Main Resource Configuration",
-												Variables: []entities.Variable{
-													{
-														Name:     "secret_id",
-														Required: true,
-														Type: entities.Type{
-															TerraformType: entities.TerraformType{
-																Type: types.TerraformString,
-															},
-														},
-														Description: "The id of the secret.",
+												Name: "module_depends_on",
+												Type: entities.Type{
+													ReadmeType: "list(dependencies)",
+													TerraformType: entities.TerraformType{
+														Type:       types.TerraformList,
+														NestedType: types.TerraformAny,
 													},
-													{
-														Name: "members",
-														Type: entities.Type{
-															TerraformType: entities.TerraformType{
-																Type:       types.TerraformSet,
-																NestedType: types.TerraformString,
-															},
-														},
-														Default: []byte("[]"),
-														Description: `Identities that will be granted the privilege in role. Each entry can have one of the following values:
+												},
+												Description: "A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency.",
+												ReadmeExample: `module_depends_on = [
+  google_network.network
+]`,
+											},
+										},
+									},
+									{
+										Level: 4,
+										Title: "Main Resource Configuration",
+										Variables: []entities.Variable{
+											{
+												Name:     "secret_id",
+												Required: true,
+												Type: entities.Type{
+													TerraformType: entities.TerraformType{
+														Type: types.TerraformString,
+													},
+												},
+												Description: "The id of the secret.",
+											},
+											{
+												Name: "members",
+												Type: entities.Type{
+													TerraformType: entities.TerraformType{
+														Type:       types.TerraformSet,
+														NestedType: types.TerraformString,
+													},
+												},
+												Default: []byte("[]"),
+												Description: `Identities that will be granted the privilege in role. Each entry can have one of the following values:
   - ` + "`allUsers`" + `: A special identifier that represents anyone who is on the internet; with or without a Google account.
   - ` + "`allAuthenticatedUsers`" + `: A special identifier that represents anyone who is authenticated with a Google account or a service account.
   - ` + "`user:{emailid}`" + `: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
@@ -150,54 +166,92 @@ module "terraform-google-secret-manager-iam" {
   - ` + "`projectOwner:projectid`" + `: Owners of the given project. For example, ` + "`projectOwner:my-example-project`" + `
   - ` + "`projectEditor:projectid`" + `: Editors of the given project. For example, ` + "`projectEditor:my-example-project`" + `
   - ` + "`projectViewer:projectid`" + `: Viewers of the given project. For example, ` + "`projectViewer:my-example-project`",
+											},
+											{
+												Name: "role",
+												Type: entities.Type{
+													TerraformType: entities.TerraformType{
+														Type: types.TerraformString,
 													},
-													{
-														Name: "role",
-														Type: entities.Type{
-															TerraformType: entities.TerraformType{
-																Type: types.TerraformString,
-															},
-														},
-														Description: "The role that should be applied. Note that custom roles must be of the format `[projects|organizations]/{parent-name}/roles/{role-name}`.",
+												},
+												Description: "The role that should be applied. Note that custom roles must be of the format `[projects|organizations]/{parent-name}/roles/{role-name}`.",
+											},
+											{
+												Name: "project",
+												Type: entities.Type{
+													TerraformType: entities.TerraformType{
+														Type: types.TerraformString,
 													},
-													{
-														Name: "project",
-														Type: entities.Type{
-															TerraformType: entities.TerraformType{
-																Type: types.TerraformString,
-															},
-														},
-														Description: "The ID of the project in which the resource belongs. If it is not provided, the project will be parsed from the identifier of the parent resource. If no project is provided in the parent identifier and no project is specified, the provider project is used.",
+												},
+												Description: "The ID of the project in which the resource belongs. If it is not provided, the project will be parsed from the identifier of the parent resource. If no project is provided in the parent identifier and no project is specified, the provider project is used.",
+											},
+											{
+												Name: "authoritative",
+												Type: entities.Type{
+													TerraformType: entities.TerraformType{
+														Type: types.TerraformBool,
 													},
-													{
-														Name: "authoritative",
-														Type: entities.Type{
-															TerraformType: entities.TerraformType{
-																Type: types.TerraformBool,
-															},
-														},
-														Default:     []byte("true"),
-														Description: "Whether to exclusively set (authoritative mode) or add (non-authoritative/additive mode) members to the role.",
+												},
+												Default:     []byte("true"),
+												Description: "Whether to exclusively set (authoritative mode) or add (non-authoritative/additive mode) members to the role.",
+											},
+											{
+												Name: "policy_bindings",
+												Type: entities.Type{
+													ReadmeType: "list(policy_bindings)",
+													TerraformType: entities.TerraformType{
+														Type:       types.TerraformList,
+														NestedType: types.TerraformAny,
 													},
-													{
-														Name: "policy_bindings",
-														Type: entities.Type{
-															ReadmeType: "list(policy_bindings)",
-															TerraformType: entities.TerraformType{
-																Type:       types.TerraformList,
-																NestedType: types.TerraformAny,
-															},
-														},
-														Description: "A list of IAM policy bindings.",
-														ReadmeExample: `policy_bindings = [{
+												},
+												Description: "A list of IAM policy bindings.",
+												ReadmeExample: `policy_bindings = [{
   role    = "roles/secretmanager.secretAccessor"
   members = ["user:member@example.com"]
 }]`,
+												Attributes: []entities.Attribute{
+													{
+														Level:       1,
+														Name:        "role",
+														Description: "The role that should be applied.",
+														Required:    true,
+														Type: entities.Type{
+															TerraformType: entities.TerraformType{
+																Type: types.TerraformString,
+															},
+														},
+													},
+													{
+														Level:       1,
+														Name:        "members",
+														Description: "Identities that will be granted the privilege in `role`.",
+														Type: entities.Type{
+															TerraformType: entities.TerraformType{
+																Type:       types.TerraformSet,
+																NestedType: types.TerraformString,
+															},
+														},
+														Default: []byte("var.members"),
+													},
+													{
+														Level:       1,
+														Name:        "condition",
+														Description: "An IAM Condition for a given binding.",
+														Type: entities.Type{
+															ReadmeType: "object(condition)",
+															TerraformType: entities.TerraformType{
+																Type: types.TerraformAny,
+															},
+														},
+														ReadmeExample: `condition = {
+  expression = "request.time < timestamp(\"2022-01-01T00:00:00Z\")"
+  title      = "expires_after_2021_12_31"
+}`,
 														Attributes: []entities.Attribute{
 															{
-																Level:       1,
-																Name:        "role",
-																Description: "The role that should be applied.",
+																Level:       2,
+																Name:        "expression",
+																Description: "Textual representation of an expression in Common Expression Language syntax.",
 																Required:    true,
 																Type: entities.Type{
 																	TerraformType: entities.TerraformType{
@@ -206,63 +260,23 @@ module "terraform-google-secret-manager-iam" {
 																},
 															},
 															{
-																Level:       1,
-																Name:        "members",
-																Description: "Identities that will be granted the privilege in `role`.",
+																Level:       2,
+																Name:        "title",
+																Description: "A title for the expression, i.e. a short string describing its purpose.",
+																Required:    true,
 																Type: entities.Type{
 																	TerraformType: entities.TerraformType{
-																		Type:       types.TerraformSet,
-																		NestedType: types.TerraformString,
+																		Type: types.TerraformString,
 																	},
 																},
-																Default: []byte("var.members"),
 															},
 															{
-																Level:       1,
-																Name:        "condition",
-																Description: "An IAM Condition for a given binding.",
+																Level:       2,
+																Name:        "description",
+																Description: "An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.",
 																Type: entities.Type{
-																	ReadmeType: "object(condition)",
 																	TerraformType: entities.TerraformType{
-																		Type: types.TerraformAny,
-																	},
-																},
-																ReadmeExample: `condition = {
-  expression = "request.time < timestamp(\"2022-01-01T00:00:00Z\")"
-  title      = "expires_after_2021_12_31"
-}`,
-																Attributes: []entities.Attribute{
-																	{
-																		Level:       2,
-																		Name:        "expression",
-																		Description: "Textual representation of an expression in Common Expression Language syntax.",
-																		Required:    true,
-																		Type: entities.Type{
-																			TerraformType: entities.TerraformType{
-																				Type: types.TerraformString,
-																			},
-																		},
-																	},
-																	{
-																		Level:       2,
-																		Name:        "title",
-																		Description: "A title for the expression, i.e. a short string describing its purpose.",
-																		Required:    true,
-																		Type: entities.Type{
-																			TerraformType: entities.TerraformType{
-																				Type: types.TerraformString,
-																			},
-																		},
-																	},
-																	{
-																		Level:       2,
-																		Name:        "description",
-																		Description: "An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.",
-																		Type: entities.Type{
-																			TerraformType: entities.TerraformType{
-																				Type: types.TerraformString,
-																			},
-																		},
+																		Type: types.TerraformString,
 																	},
 																},
 															},
@@ -270,11 +284,11 @@ module "terraform-google-secret-manager-iam" {
 													},
 												},
 											},
-											{
-												Level: 4,
-												Title: "Extended Resource Configuration",
-											},
 										},
+									},
+									{
+										Level: 4,
+										Title: "Extended Resource Configuration",
 									},
 								},
 							},
@@ -485,6 +499,7 @@ Copyright &copy; 2020-2021 [Mineiros GmbH][homepage]`,
 	want := string(bytes.TrimSpace(wantContent))
 
 	if diff := cmp.Diff(got, want); diff != "" {
+		t.Logf("\n\nWANT:\n%q\n\nGOT:\n%q\n", want, got)
 		t.Errorf("Expected golden file to match result (-want +got):\n%s", diff)
 	}
 }

--- a/internal/renderers/markdown/writer.go
+++ b/internal/renderers/markdown/writer.go
@@ -17,6 +17,7 @@ const (
 	variableTemplateName        = "variable"
 	attributeTemplateName       = "attribute"
 	typeDescriptionTemplateName = "typeDescription"
+	headerTemplateName          = "header"
 
 	varNestingLevel = 0
 )
@@ -38,11 +39,24 @@ func newMarkdownWriter(writer io.Writer) (*markdownWriter, error) {
 }
 
 func (mw *markdownWriter) writeDefinition(definition entities.Definition) error {
+	if err := mw.writeHeader(definition.Header); err != nil {
+		return err
+	}
+
 	if err := mw.writeSections(definition.Sections); err != nil {
 		return err
 	}
 
 	return mw.writeReferences(definition.References)
+}
+
+func (mw *markdownWriter) writeHeader(header entities.Header) error {
+	// Prevent empty header from being rendered
+	if len(header.Badges) > 0 || header.Image != "" {
+		return mw.writeTemplate(headerTemplateName, header)
+	}
+
+	return nil
 }
 
 func (mw *markdownWriter) writeReferences(references []entities.Reference) error {

--- a/templates/markdown/header.md
+++ b/templates/markdown/header.md
@@ -1,0 +1,7 @@
+{{- define "header"}}[<img src="{{.Image}}" width="400"/>]({{.URL}})
+
+{{range .Badges}} {{template "badge" .}}{{end}}
+{{- newline -}}{{- end -}}
+
+
+{{define "badge"}}[![{{.Text}}]({{.Image}})]({{.URL}}){{end}}

--- a/test/testdata/golden-input.tfdoc.hcl
+++ b/test/testdata/golden-input.tfdoc.hcl
@@ -1,15 +1,29 @@
+header {
+  image = "https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg"
+  url = "https://mineiros.io/?ref=terraform-google-secret-manager-iam"
+
+  badge "terraform" {
+    image = "https://img.shields.io/badge/Terraform-1.x-623CE4.svg?logo=terraform"
+    url = "https://github.com/hashicorp/terraform/releases"
+    text = "Terraform Version"
+  }
+
+  badge "google-provider"{
+    image = "https://img.shields.io/badge/google-3.x-1A73E8.svg?logo=terraform"
+    url = "https://github.com/terraform-providers/terraform-provider-google/releases"
+    text = "Google Provider Version"
+  }
+
+  badge "slack" {
+    image = "https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack"
+    url = "https://mineiros.io/slack"
+    text = "Join Slack"
+  }
+}
+
 section {
+  title = "terraform-google-secret-manager-iam"
   content = <<END
-[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][homepage]
-
-[![Terraform Version][badge-terraform]][releases-terraform]
-[![Google Provider Version][badge-tf-gcp]][releases-google-provider]
-[![Join Slack][badge-slack]][slack]
-END
-
-  section {
-    title = "terraform-google-secret-manager-iam"
-    content = <<END
 A [Terraform](https://www.terraform.io) module to create a [Google Secret Manager IAM](https://cloud.google.com/secret-manager/docs/access-control) on [Google Cloud Services (GCP)](https://cloud.google.com/).
 
 **_This module supports Terraform version 1
@@ -39,20 +53,20 @@ secure, and production-grade cloud infrastructure.
 - [License](#license)
 END
 
-    section {
-      title = "Module Features"
-      content = <<END
+  section {
+    title = "Module Features"
+    content = <<END
 This module implements the following terraform resources:
 
 - `google_secret_manager_secret_iam_binding`
 - `google_secret_manager_secret_iam_member`
 - `google_secret_manager_secret_iam_policy`
 END
-    }
+  }
 
-    section {
-      title = "Getting Started"
-      content = <<END
+  section {
+    title = "Getting Started"
+    content = <<END
 Most basic usage just setting required arguments:
 
 ```hcl
@@ -65,49 +79,49 @@ module "terraform-google-secret-manager-iam" {
 }
 ```
 END
-    }
+  }
+
+  section {
+    title = "Module Argument Reference"
+    content = "See [variables.tf] and [examples/] for details and use-cases."
 
     section {
-      title = "Module Argument Reference"
-      content = "See [variables.tf] and [examples/] for details and use-cases."
+      title = "Top-level Arguments"
 
       section {
-        title = "Top-level Arguments"
+        title = "Module Configuration"
 
-        section {
-          title = "Module Configuration"
+        variable "module_enabled" {
+          type = bool
+          description = "Specifies whether resources in the module will be created."
+          default = true
+        }
 
-          variable "module_enabled" {
-            type = bool
-            description = "Specifies whether resources in the module will be created."
-            default = true
-          }
-
-          variable "module_depends_on" {
-            type = list(any)
-            readme_type = "list(dependencies)"
-            description = "A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency."
-            readme_example = <<END
+        variable "module_depends_on" {
+          type = list(any)
+          readme_type = "list(dependencies)"
+          description = "A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency."
+          readme_example = <<END
 module_depends_on = [
   google_network.network
 ]
 END
-          }
+        }
+      }
+
+      section {
+        title = "Main Resource Configuration"
+
+        variable "secret_id" {
+          required = true
+          type = string
+          description = "The id of the secret."
         }
 
-        section {
-          title = "Main Resource Configuration"
-
-          variable "secret_id" {
-            required = true
-            type = string
-            description = "The id of the secret."
-          }
-
-          variable "members" {
-            type = set(string)
-            default = []
-            description = <<END
+        variable "members" {
+          type = set(string)
+          default = []
+          description = <<END
 Identities that will be granted the privilege in role. Each entry can have one of the following values:
   - `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account.
   - `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account.
@@ -115,76 +129,77 @@ Identities that will be granted the privilege in role. Each entry can have one o
   - `serviceAccount:{emailid}`: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   - `group:{emailid}`: An email address that represents a Google group. For example, admins@example.com.
   - `domain:{domain}`: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
+  - `projectOwner:projectid`: Owners of the given project. For example, `projectOwner:my-example-project`
+  - `projectEditor:projectid`: Editors of the given project. For example, `projectEditor:my-example-project`
+  - `projectViewer:projectid`: Viewers of the given project. For example, `projectViewer:my-example-project`
 END
-          }
+        }
 
-          variable "role" {
-            type = string
-            description = "The role that should be applied. Note that custom roles must be of the format `[projects|organizations]/{parent-name}/roles/{role-name}`."
-          }
+        variable "role" {
+          type = string
+          description = "The role that should be applied. Note that custom roles must be of the format `[projects|organizations]/{parent-name}/roles/{role-name}`."
+        }
 
-          variable "project" {
-            type = string
-            description = "The resource name of the project the policy is attached to. Its format is `projects/{project_id}`."
-          }
+        variable "project" {
+          type = string
+          description = "The ID of the project in which the resource belongs. If it is not provided, the project will be parsed from the identifier of the parent resource. If no project is provided in the parent identifier and no project is specified, the provider project is used."
+        }
 
-          variable "authoritative" {
-            description = "Whether to exclusively set (authoritative mode) or add (non-authoritative/additive mode) members to the role."
-            type = bool
-            default = true
-          }
+        variable "authoritative" {
+          description = "Whether to exclusively set (authoritative mode) or add (non-authoritative/additive mode) members to the role."
+          type = bool
+          default = true
+        }
 
-          variable "policy_bindings" {
-            type = list(any)
-            readme_type = "list(policy_bindings)"
-            description = "A list of IAM policy bindings."
-            readme_example = <<END
+        variable "policy_bindings" {
+          type = list(any)
+          readme_type = "list(policy_bindings)"
+          description = "A list of IAM policy bindings."
+          readme_example = <<END
 policy_bindings = [{
   role    = "roles/secretmanager.secretAccessor"
   members = ["user:member@example.com"]
 }]
 END
 
-            attribute "role" {
-              description = "The role that should be applied."
-              required = true
-              type = string
-            }
+          attribute "role" {
+            description = "The role that should be applied."
+            required = true
+            type = string
+          }
 
-            attribute "members" {
-              required = true
-              type = string
-              default = "var.members"
-              description = "Identities that will be granted the privilege in `role`."
-            }
+          attribute "members" {
+            type = set(string)
+            default = "var.members"
+            description = "Identities that will be granted the privilege in `role`."
+          }
 
-            attribute "condition" {
-              type = any
-              readme_type = "object(condition)"
-              description = "An IAM Condition for a given binding."
-              readme_example = <<END
+          attribute "condition" {
+            type = any
+            readme_type = "object(condition)"
+            description = "An IAM Condition for a given binding."
+            readme_example = <<END
 condition = {
   expression = "request.time < timestamp(\"2022-01-01T00:00:00Z\")"
   title      = "expires_after_2021_12_31"
 }
 END
 
-              attribute "expression" {
-                type = string
-                required = true
-                description = "Textual representation of an expression in Common Expression Language syntax."
-              }
+            attribute "expression" {
+              type = string
+              required = true
+              description = "Textual representation of an expression in Common Expression Language syntax."
+            }
 
-              attribute "title" {
-                type = string
-                required = true
-                description = "A title for the expression, i.e. a short string describing its purpose."
-              }
+            attribute "title" {
+              type = string
+              required = true
+              description = "A title for the expression, i.e. a short string describing its purpose."
+            }
 
-              attribute "description" {
-                type = string
-                description = "An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI."
-              }
+            attribute "description" {
+              type = string
+              description = "An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI."
             }
           }
         }

--- a/test/testdata/golden-readme.md
+++ b/test/testdata/golden-readme.md
@@ -1,8 +1,6 @@
-[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][homepage]
+[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>](https://mineiros.io/?ref=terraform-google-secret-manager-iam)
 
-[![Terraform Version][badge-terraform]][releases-terraform]
-[![Google Provider Version][badge-tf-gcp]][releases-google-provider]
-[![Join Slack][badge-slack]][slack]
+ [![Terraform Version](https://img.shields.io/badge/Terraform-1.x-623CE4.svg?logo=terraform)](https://github.com/hashicorp/terraform/releases) [![Google Provider Version](https://img.shields.io/badge/google-3.x-1A73E8.svg?logo=terraform)](https://github.com/terraform-providers/terraform-provider-google/releases) [![Join Slack](https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack)](https://mineiros.io/slack)
 
 # terraform-google-secret-manager-iam
 

--- a/test/testdata/input.tfdoc.hcl
+++ b/test/testdata/input.tfdoc.hcl
@@ -1,7 +1,11 @@
-section {
-  content = <<END
-[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][mineiros-website]
+header {
+  image = "https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg"
+  url = "https://www.mineiros.io"
+}
 
+section {
+  title = "root section"
+  content = <<END
 This is the root section content.
 
 Section contents support anything markdown and allow us to make references like this one: [mineiros-website]

--- a/test/testdata/output.md
+++ b/test/testdata/output.md
@@ -1,14 +1,16 @@
+[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>](https://www.mineiros.io)
 
 
-[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][mineiros-website]
+
+# root section
 
 This is the root section content.
 
 Section contents support anything markdown and allow us to make references like this one: [mineiros-website]
 
-# sections with variables
+## sections with variables
 
-## example
+### example
 
 - **`name`**: *(Optional `string`)*
 
@@ -16,7 +18,7 @@ Section contents support anything markdown and allow us to make references like 
 
   Default is `"nathan"`.
 
-## section of beers
+### section of beers
 
 an excuse to mention alcohol
 


### PR DESCRIPTION
- adds a `header` block to terradoc file definition

given an input file https://github.com/mineiros-io/terradoc/blob/93867afa04bdfe0af52c87c576af3fefb7e94503/test/testdata/golden-input.tfdoc.hcl
it generates https://github.com/mineiros-io/terradoc/blob/93867afa04bdfe0af52c87c576af3fefb7e94503/test/testdata/golden-readme.md