### PR TITLE
feat: render attribute anchors with reference to parent attr or variable

### DIFF
--- a/internal/renderers/markdown/writer_test.go
+++ b/internal/renderers/markdown/writer_test.go
@@ -168,7 +168,7 @@ func TestWriteAttribute(t *testing.T) {
 				Required:         true,
 			},
 			want: mdAttribute{
-				item:        "  - [**`string_attribute`**](#attr-string_attribute-1): *(**Required** `string`, Forces new resource)*<a name=\"attr-string_attribute-1\"></a>",
+				item:        "  - [**`string_attribute`**](#attr-string_attribute-parent_var_name): *(**Required** `string`, Forces new resource)*<a name=\"attr-string_attribute-parent_var_name\"></a>",
 				description: "  i am this attribute's description",
 			},
 		},
@@ -184,7 +184,7 @@ func TestWriteAttribute(t *testing.T) {
 				Required:         false,
 			},
 			want: mdAttribute{
-				item: "    - [**`number_attribute`**](#attr-number_attribute-2): *(Optional `number`, Forces new resource)*<a name=\"attr-number_attribute-2\"></a>",
+				item: "    - [**`number_attribute`**](#attr-number_attribute-parent_var_name): *(Optional `number`, Forces new resource)*<a name=\"attr-number_attribute-parent_var_name\"></a>",
 			},
 		},
 		{
@@ -199,7 +199,7 @@ func TestWriteAttribute(t *testing.T) {
 				Required:         false,
 			},
 			want: mdAttribute{
-				item: "- [**`bool_attribute`**](#attr-bool_attribute-0): *(Optional `bool`)*<a name=\"attr-bool_attribute-0\"></a>",
+				item: "- [**`bool_attribute`**](#attr-bool_attribute-parent_var_name): *(Optional `bool`)*<a name=\"attr-bool_attribute-parent_var_name\"></a>",
 			},
 		},
 		{
@@ -213,7 +213,7 @@ func TestWriteAttribute(t *testing.T) {
 				Default: []byte("123"),
 			},
 			want: mdAttribute{
-				item:        "  - [**`i_have_a_default`**](#attr-i_have_a_default-1): *(Optional `number`)*<a name=\"attr-i_have_a_default-1\"></a>",
+				item:        "  - [**`i_have_a_default`**](#attr-i_have_a_default-parent_var_name): *(Optional `number`)*<a name=\"attr-i_have_a_default-parent_var_name\"></a>",
 				description: "  Default is `123`.",
 			},
 		},
@@ -222,7 +222,7 @@ func TestWriteAttribute(t *testing.T) {
 			buf := &bytes.Buffer{}
 
 			writer := newTestWriter(t, buf)
-			err := writer.writeAttribute(tt.attr)
+			err := writer.writeAttribute(tt.attr, "parent_var_name")
 			assert.NoError(t, err)
 
 			assertMarkdownHasAttribute(t, buf, tt.want)

--- a/templates/markdown/attribute.md
+++ b/templates/markdown/attribute.md
@@ -1,4 +1,4 @@
-{{define "attribute"}}{{indent (multiply .Level 2) "-"}} [**`{{.Name}}`**](#attr-{{.Name}}-{{.Level}}): *({{if .Required}}**Required**{{else}}Optional{{end}} `{{template "variableType" .Type}}`{{if .ForcesRecreation}}, Forces new resource{{end}})*<a name="attr-{{.Name}}-{{.Level}}"></a>
+{{define "attribute"}}{{indent (multiply .Level 2) "-"}} [**`{{.Name}}`**](#attr-{{.Name}}-{{.ParentName}}): *({{if .Required}}**Required**{{else}}Optional{{end}} `{{template "variableType" .Type}}`{{if .ForcesRecreation}}, Forces new resource{{end}})*<a name="attr-{{.Name}}-{{.ParentName}}"></a>
 
 {{- if .Description}}{{- newline}}{{indent (getIndent .Level) .Description}}{{end}}
 

--- a/test/testdata/golden-readme.md
+++ b/test/testdata/golden-readme.md
@@ -133,17 +133,17 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   Each object in the list accepts the following attributes:
 
-  - [**`role`**](#attr-role-1): *(**Required** `string`)*<a name="attr-role-1"></a>
+  - [**`role`**](#attr-role-policy_bindings): *(**Required** `string`)*<a name="attr-role-policy_bindings"></a>
 
     The role that should be applied.
 
-  - [**`members`**](#attr-members-1): *(Optional `set(string)`)*<a name="attr-members-1"></a>
+  - [**`members`**](#attr-members-policy_bindings): *(Optional `set(string)`)*<a name="attr-members-policy_bindings"></a>
 
     Identities that will be granted the privilege in `role`.
 
     Default is `"var.members"`.
 
-  - [**`condition`**](#attr-condition-1): *(Optional `object(condition)`)*<a name="attr-condition-1"></a>
+  - [**`condition`**](#attr-condition-policy_bindings): *(Optional `object(condition)`)*<a name="attr-condition-policy_bindings"></a>
 
     An IAM Condition for a given binding.
 
@@ -158,15 +158,15 @@ See [variables.tf] and [examples/] for details and use-cases.
 
     The object accepts the following attributes:
 
-    - [**`expression`**](#attr-expression-2): *(**Required** `string`)*<a name="attr-expression-2"></a>
+    - [**`expression`**](#attr-expression-condition-policy_bindings): *(**Required** `string`)*<a name="attr-expression-condition-policy_bindings"></a>
 
       Textual representation of an expression in Common Expression Language syntax.
 
-    - [**`title`**](#attr-title-2): *(**Required** `string`)*<a name="attr-title-2"></a>
+    - [**`title`**](#attr-title-condition-policy_bindings): *(**Required** `string`)*<a name="attr-title-condition-policy_bindings"></a>
 
       A title for the expression, i.e. a short string describing its purpose.
 
-    - [**`description`**](#attr-description-2): *(Optional `string`)*<a name="attr-description-2"></a>
+    - [**`description`**](#attr-description-condition-policy_bindings): *(Optional `string`)*<a name="attr-description-condition-policy_bindings"></a>
 
       An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
 

--- a/test/testdata/markdown-structure.md
+++ b/test/testdata/markdown-structure.md
@@ -25,16 +25,16 @@ We can add infinite subsections!
 
   Each object in the list accepts the following attributes:
 
-  - [**`name`**](#attr-name-1): *(Optional `string`)*<a name="attr-name-1"></a>
+  - [**`name`**](#attr-name-test_objects): *(Optional `string`)*<a name="attr-name-test_objects"></a>
 
     A string
 
-  - [**`something_complex`**](#attr-something_complex-1): *(Optional `any`)*<a name="attr-something_complex-1"></a>
+  - [**`something_complex`**](#attr-something_complex-test_objects): *(Optional `any`)*<a name="attr-something_complex-test_objects"></a>
 
     Some other object
 
     The object accepts the following attributes:
 
-    - [**`nested_string`**](#attr-nested_string-2): *(Optional `string`)*<a name="attr-nested_string-2"></a>
+    - [**`nested_string`**](#attr-nested_string-something_complex-test_objects): *(Optional `string`)*<a name="attr-nested_string-something_complex-test_objects"></a>
 
       a nested string


### PR DESCRIPTION
Currently, we're rendering attribute references using the pattern `{attribute-name}-{level}` but this may cause reference clashing (when 2 variables have the same attribute name, for example) and make the generated links not very legible.

with this PR, we render the attribute references associated to their parent, that might be either a variable or an attribute:

for variable attributes: `{attribute-name}-{variable-name}`
for nested attributes: `{attribute-name}-{parent-attribute-name}-{variable-name}`
for deep nested attributes: `{attribute-name}-{parent-attribute-name}-{grandparent-attribute-name}-{...}-{variable-name}`