### PR TITLE
fix: get variable expression tokens for raw json attributes

### DIFF
--- a/test/testdata/golden-input.tfdoc.hcl
+++ b/test/testdata/golden-input.tfdoc.hcl
@@ -153,8 +153,7 @@ END
 
           attribute "members" {
             type = set(string)
-            # BUG: `var.members` should not be a string - currently it fails as HCL tries to evaluate the expression
-            default = "var.members"
+            default = var.members
             description = "Identities that will be granted the privilege in `role`."
           }
 

--- a/test/testdata/golden-readme.md
+++ b/test/testdata/golden-readme.md
@@ -141,7 +141,7 @@ See [variables.tf] and [examples/] for details and use-cases.
 
     Identities that will be granted the privilege in `role`.
 
-    Default is `"var.members"`.
+    Default is `var.members`.
 
   - [**`condition`**](#attr-condition-policy_bindings): *(Optional `object(condition)`)*<a name="attr-condition-policy_bindings"></a>
 


### PR DESCRIPTION
now we can set variable/attribute defaults that refer to variables:

```hcl
attribute "members" {
  type = set(string)
  default = var.members
  description = "Identities that will be granted the privilege in `role`."
}
```