### PR TITLE
[Ch4358] consolidate types

### DIFF
--- a/internal/entities/type.go
+++ b/internal/entities/type.go
@@ -4,19 +4,16 @@ import "github.com/mineiros-io/terradoc/internal/types"
 
 // Type represents a variable or attribute type with its readme and Terraform type data
 type Type struct {
-	// Name is the name of the variable or attribute which contains this type definition
-	Name string `json:"name"`
-	// TerraformType is the specific Terraform type definition for this type
-	TerraformType TerraformType `json:"terraform_type"`
-	// ReadmeType is an optional type to be rendered on the README document. Can be any string value as opposed to the `Type` field
-	ReadmeType string `json:"readme_type,omitempty"`
+	// TFType is the specific Terraform type definition for this type
+	TFType types.TerraformType `json:"type"`
+	// TFTypeLabel is an optional label for the TerraformType
+	TFTypeLabel string `json:"type_label"`
+	// TFType is an optional Terraform type definition for the nested type
+	NestedTFType types.TerraformType `json:"nested_type"`
+	// TFTypeLabel is an optional label for the nested TerraformType
+	NestedTFTypeLabel string `json:"nested_type_label"`
 }
 
-type TerraformType struct {
-	Type       types.TerraformType // Type is the TerraformType
-	NestedType types.TerraformType // NestedType is the nested TerraformType
-}
-
-func (t TerraformType) HasNestedType() bool {
-	return t.NestedType != types.TerraformEmptyType
+func (t Type) HasNestedType() bool {
+	return t.NestedTFType != types.TerraformEmptyType
 }

--- a/internal/parser/hclparser/attributes.go
+++ b/internal/parser/hclparser/attributes.go
@@ -78,7 +78,14 @@ func createAttributeFromHCLAttributes(attrs hcl.Attributes, name string, level i
 		return entities.Attribute{}, err
 	}
 
-	attr.Type, err = getType(attrs, name)
+	// type definition
+	readmeType := getAttribute(attrs, readmeTypeAttributeName)
+	if !readmeType.isNil() {
+		attr.Type, err = readmeType.TypeFromString()
+	} else {
+		attr.Type, err = getAttribute(attrs, typeAttributeName).Type()
+	}
+
 	if err != nil {
 		return entities.Attribute{}, err
 	}

--- a/internal/parser/hclparser/hclparser.go
+++ b/internal/parser/hclparser/hclparser.go
@@ -15,7 +15,7 @@ const (
 	contentAttributeName          = "content"
 	descriptionAttributeName      = "description"
 	typeAttributeName             = "type"
-	readmeTypeAttributeName       = "readme_type"
+	readmeTypeAttributeName       = "readmeType"
 	defaultAttributeName          = "default"
 	requiredAttributeName         = "required"
 	forcesRecreationAttributeName = "forces_recreation"
@@ -93,22 +93,4 @@ func getAttribute(attrs hcl.Attributes, name string) *hclAttribute {
 	}
 
 	return &hclAttribute{}
-}
-
-func getType(attrs hcl.Attributes, attrName string) (entities.Type, error) {
-	readmeType, err := getAttribute(attrs, readmeTypeAttributeName).String()
-	if err != nil {
-		return entities.Type{}, err
-	}
-
-	terraformType, err := getAttribute(attrs, typeAttributeName).TerraformType()
-	if err != nil {
-		return entities.Type{}, err
-	}
-
-	return entities.Type{
-		TerraformType: terraformType,
-		ReadmeType:    readmeType,
-		Name:          attrName,
-	}, nil
 }

--- a/internal/parser/hclparser/hclparser_test.go
+++ b/internal/parser/hclparser/hclparser_test.go
@@ -45,14 +45,23 @@ Section contents support anything markdown and allow us to make references like 
 										Title: "example",
 										Variables: []entities.Variable{
 											{
-												Name: "name",
+												Name: "person",
 												Type: entities.Type{
-													TerraformType: entities.TerraformType{
-														Type: types.TerraformString,
+													TFType:      types.TerraformObject,
+													TFTypeLabel: "person",
+												},
+												Description: "describes the last person who bothered to change this file",
+												Default:     json.RawMessage("nathan"),
+												Attributes: []entities.Attribute{
+													{
+														Name: "name",
+														Type: entities.Type{
+															TFType: types.TerraformString,
+														},
+														Description: "the person's name",
+														Default:     json.RawMessage("nathan"),
 													},
 												},
-												Description: "describes the name of the last person who bothered to change this file",
-												Default:     json.RawMessage("nathan"),
 											},
 										},
 									},
@@ -64,11 +73,9 @@ Section contents support anything markdown and allow us to make references like 
 											{
 												Name: "beers",
 												Type: entities.Type{
-													TerraformType: entities.TerraformType{
-														Type:       types.TerraformList,
-														NestedType: types.TerraformAny,
-													},
-													ReadmeType: "list(beer)",
+													TFType:            types.TerraformList,
+													NestedTFType:      types.TerraformObject,
+													NestedTFTypeLabel: "beer",
 												},
 												Description:      "a list of beers",
 												Default:          json.RawMessage("[]"),
@@ -79,9 +86,7 @@ Section contents support anything markdown and allow us to make references like 
 													{
 														Name: "name",
 														Type: entities.Type{
-															TerraformType: entities.TerraformType{
-																Type: types.TerraformString,
-															},
+															TFType: types.TerraformString,
 														},
 														Description:      "the name of the beer",
 														ForcesRecreation: false,
@@ -89,9 +94,7 @@ Section contents support anything markdown and allow us to make references like 
 													{
 														Name: "type",
 														Type: entities.Type{
-															TerraformType: entities.TerraformType{
-																Type: types.TerraformString,
-															},
+															TFType: types.TerraformString,
 														},
 														Description:      "the type of the beer",
 														ForcesRecreation: true,
@@ -99,12 +102,18 @@ Section contents support anything markdown and allow us to make references like 
 													{
 														Name: "abv",
 														Type: entities.Type{
-															TerraformType: entities.TerraformType{
-																Type: types.TerraformNumber,
-															},
+															TFType: types.TerraformNumber,
 														},
 														Description:      "beer's alcohol by volume content",
 														ForcesRecreation: true,
+													},
+													{
+														Name: "tags",
+														Type: entities.Type{
+															TFType:       types.TerraformList,
+															NestedTFType: types.TerraformString,
+														},
+														Description: "a list of tags for the beer",
 													},
 												},
 											},
@@ -332,8 +341,11 @@ func assertVariableEquals(t *testing.T, want, got entities.Variable) {
 	// redundant since we're finding the variable by name
 	assert.EqualStrings(t, want.Name, got.Name)
 	assert.EqualStrings(t, want.Description, got.Description)
-	assert.EqualInts(t, int(want.Type.TerraformType.Type), int(got.Type.TerraformType.Type))
-	assert.EqualInts(t, int(want.Type.TerraformType.NestedType), int(got.Type.TerraformType.NestedType))
+	assert.EqualStrings(t, want.Type.TFType.String(), got.Type.TFType.String())
+	assert.EqualStrings(t, want.Type.TFTypeLabel, got.Type.TFTypeLabel)
+
+	assert.EqualStrings(t, want.Type.NestedTFType.String(), got.Type.NestedTFType.String())
+	assert.EqualStrings(t, want.Type.NestedTFTypeLabel, got.Type.NestedTFTypeLabel)
 
 	assertEqualAttributes(t, want.Attributes, got.Attributes)
 }
@@ -375,8 +387,12 @@ func assertAttributeEquals(t *testing.T, want, got entities.Attribute) {
 	// redundant since we're finding the attribute by name
 	assert.EqualStrings(t, want.Name, got.Name)
 	assert.EqualStrings(t, want.Description, got.Description)
-	assert.EqualInts(t, int(want.Type.TerraformType.Type), int(got.Type.TerraformType.Type))
-	assert.EqualInts(t, int(want.Type.TerraformType.NestedType), int(got.Type.TerraformType.NestedType))
+
+	assert.EqualStrings(t, want.Type.TFType.String(), got.Type.TFType.String())
+	assert.EqualStrings(t, want.Type.TFTypeLabel, got.Type.TFTypeLabel)
+
+	assert.EqualStrings(t, want.Type.NestedTFType.String(), got.Type.NestedTFType.String())
+	assert.EqualStrings(t, want.Type.NestedTFTypeLabel, got.Type.NestedTFTypeLabel)
 
 	assertEqualAttributes(t, want.Attributes, got.Attributes)
 }

--- a/internal/parser/hclparser/hclschema/hclschema.go
+++ b/internal/parser/hclparser/hclschema/hclschema.go
@@ -120,10 +120,6 @@ func VariableSchema() *hcl.BodySchema {
 				Required: true,
 			},
 			{
-				Name:     "readme_type",
-				Required: false,
-			},
-			{
 				Name:     "description",
 				Required: false,
 			},
@@ -141,6 +137,10 @@ func VariableSchema() *hcl.BodySchema {
 			},
 			{
 				Name:     "readme_example",
+				Required: false,
+			},
+			{
+				Name:     "readme_type",
 				Required: false,
 			},
 		},
@@ -173,15 +173,15 @@ func AttributeSchema() *hcl.BodySchema {
 				Required: false,
 			},
 			{
-				Name:     "readme_type",
-				Required: false,
-			},
-			{
 				Name:     "default",
 				Required: false,
 			},
 			{
 				Name:     "readme_example",
+				Required: false,
+			},
+			{
+				Name:     "readme_type",
 				Required: false,
 			},
 		},

--- a/internal/parser/hclparser/hclschema/hclschema_test.go
+++ b/internal/parser/hclparser/hclschema/hclschema_test.go
@@ -68,6 +68,7 @@ func TestAttributeSchema(t *testing.T) {
 
 	// schema attributes
 	assertHasAttribute(t, s, "type", true)
+	assertHasAttribute(t, s, "readme_type", false)
 	assertHasAttribute(t, s, "description", false)
 	assertHasAttribute(t, s, "required", false)
 	assertHasAttribute(t, s, "forces_recreation", false)

--- a/internal/parser/hclparser/hcltype.go
+++ b/internal/parser/hclparser/hcltype.go
@@ -1,0 +1,172 @@
+package hclparser
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/mineiros-io/terradoc/internal/entities"
+	"github.com/mineiros-io/terradoc/internal/types"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/gocty"
+)
+
+var typeObj = map[string]cty.Type{
+	"type":            cty.Number,
+	"typeLabel":       cty.String,
+	"nestedType":      cty.Number,
+	"nestedTypeLabel": cty.String,
+}
+
+func nestedTypeFunc(tfType types.TerraformType) function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name:             "nestedTypeLabel",
+				Type:             cty.String,
+				AllowDynamicType: true,
+			},
+		},
+		Type: function.StaticReturnType(cty.Object(typeObj)),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			var nestedType types.TerraformType
+			var nestedLabel string
+
+			nestedTypeName := args[0].AsString()
+
+			nestedType, ok := types.TerraformTypes[nestedTypeName]
+			if !ok {
+				nestedType = types.TerraformObject
+
+				nestedLabel = nestedTypeName
+			}
+
+			return cty.ObjectVal(map[string]cty.Value{
+				"type":            cty.NumberIntVal(int64(tfType)),
+				"typeLabel":       cty.StringVal(""), // need to pass empty value here so cty doesn't panic
+				"nestedType":      cty.NumberIntVal(int64(nestedType)),
+				"nestedTypeLabel": cty.StringVal(nestedLabel),
+			}), nil
+		},
+	})
+}
+
+func complexTypeFunc(tfType types.TerraformType) function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name:             "typeLabel",
+				Type:             cty.String,
+				AllowDynamicType: true,
+			},
+		},
+		Type: function.StaticReturnType(cty.Object(typeObj)),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			typeLabel := args[0].AsString()
+
+			return cty.ObjectVal(map[string]cty.Value{
+				"type":      cty.NumberIntVal(int64(tfType)),
+				"typeLabel": cty.StringVal(typeLabel),
+				// the following empty values need to be set to the attributes
+				// otherwise cty panics
+				"nestedType":      cty.NumberIntVal(int64(types.TerraformEmptyType)),
+				"nestedTypeLabel": cty.StringVal(""), //
+			}), nil
+		},
+	})
+}
+
+func getComplexType(expr hcl.Expression) (entities.Type, error) {
+	got, exprDiags := expr.Value(getEvalContextForExpr(expr))
+	if exprDiags.HasErrors() {
+		return entities.Type{}, fmt.Errorf("getting expression value: %v", exprDiags.Errs())
+	}
+	var err error
+	var tfType, nestedTFType types.TerraformType
+
+	err = gocty.FromCtyValue(got.GetAttr("type"), &tfType)
+	if err != nil {
+		return entities.Type{}, fmt.Errorf("getting type definition: %v", err)
+	}
+
+	err = gocty.FromCtyValue(got.GetAttr("nestedType"), &nestedTFType)
+	if err != nil {
+		return entities.Type{}, fmt.Errorf("getting nested type definition: %v", err)
+	}
+
+	var typeLabel, nestedTypeLabel string
+	err = gocty.FromCtyValue(got.GetAttr("typeLabel"), &typeLabel)
+	if err != nil {
+		return entities.Type{}, fmt.Errorf("getting type label: %v", err)
+	}
+
+	err = gocty.FromCtyValue(got.GetAttr("nestedTypeLabel"), &nestedTypeLabel)
+	if err != nil {
+		return entities.Type{}, fmt.Errorf("getting nested type label: %v", err)
+	}
+
+	return entities.Type{
+		TFType:            tfType,
+		TFTypeLabel:       typeLabel,
+		NestedTFType:      nestedTFType,
+		NestedTFTypeLabel: nestedTypeLabel,
+	}, nil
+}
+
+func getTypeFromExpression(expr hcl.Expression) (entities.Type, error) {
+	kw := hcl.ExprAsKeyword(expr)
+
+	switch kw {
+	case "string", "number", "bool":
+		return entities.Type{TFType: types.TerraformTypes[kw]}, nil
+	case "list", "object", "map", "tuple":
+		// invalid as these types should be function calls
+		return entities.Type{}, fmt.Errorf("type %q needs an argument", kw)
+	}
+
+	// TODO: how to make this decent?
+	if kw != "" && !(strings.HasPrefix(kw, "list") ||
+		strings.HasPrefix(kw, "object") ||
+		strings.HasPrefix(kw, "map") ||
+		strings.HasPrefix(kw, "tuple")) {
+		return entities.Type{}, fmt.Errorf("type %q is invalid", kw)
+	}
+
+	return getComplexType(expr)
+}
+
+// this function exists to make it possible to parse `type` attribute expressions and `readme_type`
+// attribute strings in the same way, so they are compatible even though they have different types
+func getTypeFromString(str string) (entities.Type, error) {
+	expr, parseDiags := hclsyntax.ParseExpression([]byte(str), "", hcl.Pos{Line: 1, Column: 1, Byte: 0})
+	if parseDiags.HasErrors() {
+		return entities.Type{}, fmt.Errorf("parsing type string expression: %v", parseDiags.Errs())
+	}
+
+	return getTypeFromExpression(expr)
+}
+
+func getVariablesMap(expr hcl.Expression) map[string]cty.Value {
+	myMap := make(map[string]cty.Value)
+	for _, variable := range expr.Variables() {
+		name := variable.RootName()
+
+		myMap[name] = cty.StringVal(name)
+	}
+
+	return myMap
+}
+
+func getEvalContextForExpr(expr hcl.Expression) *hcl.EvalContext {
+	return &hcl.EvalContext{
+		Functions: map[string]function.Function{
+			"object": complexTypeFunc(types.TerraformObject),
+			"map":    complexTypeFunc(types.TerraformMap),
+			"list":   nestedTypeFunc(types.TerraformList),
+			"set":    nestedTypeFunc(types.TerraformSet),
+		},
+		Variables: getVariablesMap(expr),
+	}
+}

--- a/internal/parser/hclparser/hcltype_test.go
+++ b/internal/parser/hclparser/hcltype_test.go
@@ -1,0 +1,112 @@
+package hclparser
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/madlambda/spells/assert"
+	"github.com/mineiros-io/terradoc/internal/types"
+)
+
+var tests = []struct {
+	expression          string
+	wantType            types.TerraformType
+	wantTypeLabel       string
+	wantNestedType      types.TerraformType
+	wantNestedTypeLabel string
+}{
+	{
+		expression:          `list(my_object)`,
+		wantType:            types.TerraformList,
+		wantNestedType:      types.TerraformObject,
+		wantNestedTypeLabel: "my_object",
+	},
+	{
+		expression:     `list(string)`,
+		wantType:       types.TerraformList,
+		wantNestedType: types.TerraformString,
+	},
+	{
+		expression:     `set(number)`,
+		wantType:       types.TerraformSet,
+		wantNestedType: types.TerraformNumber,
+	},
+	{
+		expression:     `list(number)`,
+		wantType:       types.TerraformList,
+		wantNestedType: types.TerraformNumber,
+	},
+	{
+		expression:          `list(another_object)`,
+		wantType:            types.TerraformList,
+		wantNestedType:      types.TerraformObject,
+		wantNestedTypeLabel: "another_object",
+	},
+	{
+		expression:          `set(another_object)`,
+		wantType:            types.TerraformSet,
+		wantNestedType:      types.TerraformObject,
+		wantNestedTypeLabel: "another_object",
+	},
+	{
+		expression:    `object(my_object_name)`,
+		wantType:      types.TerraformObject,
+		wantTypeLabel: "my_object_name",
+	},
+	{
+		expression:    `map(my_object_name)`,
+		wantType:      types.TerraformMap,
+		wantTypeLabel: "my_object_name",
+	},
+	{
+		expression:    `object(another_object_name)`,
+		wantType:      types.TerraformObject,
+		wantTypeLabel: "another_object_name",
+	},
+	{
+		expression: `string`,
+		wantType:   types.TerraformString,
+	},
+	{
+		expression: `number`,
+		wantType:   types.TerraformNumber,
+	},
+	{
+		expression: `bool`,
+		wantType:   types.TerraformBool,
+	},
+}
+
+func TestGetTypeFromExpression(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.expression, func(t *testing.T) {
+			expr, parseDiags := hclsyntax.ParseExpression([]byte(tt.expression), "", hcl.Pos{Line: 1, Column: 1, Byte: 0})
+			if parseDiags.HasErrors() {
+				t.Errorf("Error parsing expression: %v", parseDiags.Errs())
+			}
+
+			got, err := getTypeFromExpression(expr)
+			assert.NoError(t, err)
+
+			assert.EqualStrings(t, tt.wantType.String(), got.TFType.String())
+			assert.EqualStrings(t, tt.wantTypeLabel, got.TFTypeLabel)
+			assert.EqualStrings(t, tt.wantNestedType.String(), got.NestedTFType.String())
+			assert.EqualStrings(t, tt.wantNestedTypeLabel, got.NestedTFTypeLabel)
+		})
+	}
+}
+
+func TestGetTypeFromString(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.expression, func(t *testing.T) {
+			got, err := getTypeFromString(tt.expression)
+			assert.NoError(t, err)
+
+			assert.EqualStrings(t, tt.wantType.String(), got.TFType.String())
+			assert.EqualStrings(t, tt.wantTypeLabel, got.TFTypeLabel)
+			assert.EqualStrings(t, tt.wantNestedType.String(), got.NestedTFType.String())
+			assert.EqualStrings(t, tt.wantNestedTypeLabel, got.NestedTFTypeLabel)
+		})
+	}
+}

--- a/internal/parser/hclparser/variables.go
+++ b/internal/parser/hclparser/variables.go
@@ -79,7 +79,14 @@ func createVariableFromHCLAttributes(attrs hcl.Attributes, name string) (entitie
 		return entities.Variable{}, err
 	}
 
-	variable.Type, err = getType(attrs, name)
+	// type definition
+	readmeType := getAttribute(attrs, readmeTypeAttributeName)
+	if !readmeType.isNil() {
+		variable.Type, err = readmeType.TypeFromString()
+	} else {
+		variable.Type, err = getAttribute(attrs, typeAttributeName).Type()
+	}
+
 	if err != nil {
 		return entities.Variable{}, err
 	}

--- a/internal/renderers/markdown/markdown_test.go
+++ b/internal/renderers/markdown/markdown_test.go
@@ -41,9 +41,7 @@ func TestRender(t *testing.T) {
 							{
 								Name: "simple_string",
 								Type: entities.Type{
-									TerraformType: entities.TerraformType{
-										Type: types.TerraformString,
-									},
+									TFType: types.TerraformString,
 								},
 								Description: "A simple string",
 							},
@@ -57,11 +55,9 @@ func TestRender(t *testing.T) {
 								Name:    "test_objects",
 								Default: []byte("[]"),
 								Type: entities.Type{
-									ReadmeType: "list(test_object)",
-									TerraformType: entities.TerraformType{
-										Type:       types.TerraformList,
-										NestedType: types.TerraformAny,
-									},
+									TFType:            types.TerraformList,
+									NestedTFType:      types.TerraformObject,
+									NestedTFTypeLabel: "test_object",
 								},
 								Attributes: []entities.Attribute{
 									{
@@ -69,9 +65,7 @@ func TestRender(t *testing.T) {
 										Name:        "name",
 										Description: "A string",
 										Type: entities.Type{
-											TerraformType: entities.TerraformType{
-												Type: types.TerraformString,
-											},
+											TFType: types.TerraformString,
 										},
 									},
 									{
@@ -79,9 +73,8 @@ func TestRender(t *testing.T) {
 										Name:        "something_complex",
 										Description: "Some other object",
 										Type: entities.Type{
-											TerraformType: entities.TerraformType{
-												Type: types.TerraformAny,
-											},
+											TFType:      types.TerraformObject,
+											TFTypeLabel: "nested_object",
 										},
 										Attributes: []entities.Attribute{
 											{
@@ -89,9 +82,7 @@ func TestRender(t *testing.T) {
 												Name:        "nested_string",
 												Description: "a nested string",
 												Type: entities.Type{
-													TerraformType: entities.TerraformType{
-														Type: types.TerraformString,
-													},
+													TFType: types.TerraformString,
 												},
 											},
 										},

--- a/internal/renderers/markdown/writer_test.go
+++ b/internal/renderers/markdown/writer_test.go
@@ -70,7 +70,7 @@ func TestWriteVariable(t *testing.T) {
 			variable: entities.Variable{
 				Name: "string_variable",
 				Type: entities.Type{
-					TerraformType: entities.TerraformType{Type: types.TerraformString},
+					TFType: types.TerraformString,
 				},
 				ForcesRecreation: true,
 				Required:         true,
@@ -88,7 +88,7 @@ func TestWriteVariable(t *testing.T) {
 			variable: entities.Variable{
 				Name: "number_variable",
 				Type: entities.Type{
-					TerraformType: entities.TerraformType{Type: types.TerraformNumber},
+					TFType: types.TerraformNumber,
 				},
 				ForcesRecreation: true,
 				Required:         false,
@@ -104,7 +104,7 @@ func TestWriteVariable(t *testing.T) {
 			variable: entities.Variable{
 				Name: "bool_variable",
 				Type: entities.Type{
-					TerraformType: entities.TerraformType{Type: types.TerraformBool},
+					TFType: types.TerraformBool,
 				},
 				ForcesRecreation: false,
 				Required:         false,
@@ -118,7 +118,7 @@ func TestWriteVariable(t *testing.T) {
 			variable: entities.Variable{
 				Name: "obj_variable",
 				Type: entities.Type{
-					TerraformType: entities.TerraformType{Type: types.TerraformObject},
+					TFType: types.TerraformObject,
 				},
 				ForcesRecreation: true,
 				Required:         true,
@@ -162,7 +162,7 @@ func TestWriteAttribute(t *testing.T) {
 				Name:        "string_attribute",
 				Description: "i am this attribute's description",
 				Type: entities.Type{
-					TerraformType: entities.TerraformType{Type: types.TerraformString},
+					TFType: types.TerraformString,
 				},
 				ForcesRecreation: true,
 				Required:         true,
@@ -178,7 +178,7 @@ func TestWriteAttribute(t *testing.T) {
 				Level: 2,
 				Name:  "number_attribute",
 				Type: entities.Type{
-					TerraformType: entities.TerraformType{Type: types.TerraformNumber},
+					TFType: types.TerraformNumber,
 				},
 				ForcesRecreation: true,
 				Required:         false,
@@ -193,7 +193,7 @@ func TestWriteAttribute(t *testing.T) {
 				Level: 0,
 				Name:  "bool_attribute",
 				Type: entities.Type{
-					TerraformType: entities.TerraformType{Type: types.TerraformBool},
+					TFType: types.TerraformBool,
 				},
 				ForcesRecreation: false,
 				Required:         false,
@@ -208,7 +208,7 @@ func TestWriteAttribute(t *testing.T) {
 				Level: 1,
 				Name:  "i_have_a_default",
 				Type: entities.Type{
-					TerraformType: entities.TerraformType{Type: types.TerraformNumber},
+					TFType: types.TerraformNumber,
 				},
 				Default: []byte("123"),
 			},

--- a/templates/markdown/typeDescription.md
+++ b/templates/markdown/typeDescription.md
@@ -1,5 +1,10 @@
 {{define "typeDescription"}}
-{{- if .TerraformType.HasNestedType }}{{indent .IndentLevel "Each object in the"}} {{.TerraformType.Type}} accepts the following attributes:{{newline}}
-{{- else -}}
-{{indent .IndentLevel "The object accepts the following attributes:" }}{{newline}}{{end}}
+    {{- if .HasNestedType }}{{indent .IndentLevel "Each"}} `{{.NestedTFTypeLabel}}` object in the {{.Type.TFType}} accepts the following attributes:{{newline}}
+    {{- else -}}
+        {{- if .TFTypeLabel -}}
+            {{indent .IndentLevel "The"}} `{{.TFTypeLabel}}` object accepts the following attributes:{{newline}}
+        {{- else -}}
+            {{indent .IndentLevel "The object accepts the following attributes:" }}{{newline}}
+        {{- end -}}
+    {{- end -}}
 {{- end -}}

--- a/templates/markdown/variableType.md
+++ b/templates/markdown/variableType.md
@@ -1,11 +1,19 @@
 {{- define "variableType" -}}
-{{- if .ReadmeType -}}
-  {{- .ReadmeType -}}
-{{- else -}}
-    {{- if .TerraformType.HasNestedType -}}
-        {{- .TerraformType.Type -}}({{.TerraformType.NestedType}})
+    {{- if .HasNestedType -}}
+        {{template "nestedVariableType" .}}
     {{- else -}}
-        {{- .TerraformType.Type -}}
+        {{- if .TFTypeLabel -}}
+            {{- .TFType -}}({{ .TFTypeLabel }})
+        {{- else -}}
+            {{- .TFType -}}
+        {{- end -}}
     {{- end -}}
 {{- end -}}
+
+{{- define "nestedVariableType" -}}
+    {{- if .NestedTFTypeLabel -}}
+        {{- .TFType -}}({{.NestedTFTypeLabel}})
+    {{- else -}}
+        {{- .TFType -}}({{.NestedTFType}})
+    {{- end -}}
 {{- end -}}

--- a/test/testdata/golden-input.tfdoc.hcl
+++ b/test/testdata/golden-input.tfdoc.hcl
@@ -81,8 +81,7 @@ END
         }
 
         variable "module_depends_on" {
-          type = list(any)
-          readme_type = "list(dependencies)"
+          type = list(dependencies)
           description = "A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency."
           readme_example = <<END
 module_depends_on = [
@@ -135,8 +134,7 @@ END
         }
 
         variable "policy_bindings" {
-          type = list(any)
-          readme_type = "list(policy_bindings)"
+          type = list(policy_bindings)
           description = "A list of IAM policy bindings."
           readme_example = <<END
 policy_bindings = [{
@@ -158,8 +156,7 @@ END
           }
 
           attribute "condition" {
-            type = any
-            readme_type = "object(condition)"
+            type = object(condition)
             description = "An IAM Condition for a given binding."
             readme_example = <<END
 condition = {

--- a/test/testdata/golden-readme.md
+++ b/test/testdata/golden-readme.md
@@ -131,7 +131,7 @@ See [variables.tf] and [examples/] for details and use-cases.
   }]
   ```
 
-  Each object in the list accepts the following attributes:
+  Each `policy_bindings` object in the list accepts the following attributes:
 
   - [**`role`**](#attr-role-policy_bindings): *(**Required** `string`)*<a name="attr-role-policy_bindings"></a>
 
@@ -156,7 +156,7 @@ See [variables.tf] and [examples/] for details and use-cases.
     }
     ```
 
-    The object accepts the following attributes:
+    The `condition` object accepts the following attributes:
 
     - [**`expression`**](#attr-expression-condition-policy_bindings): *(**Required** `string`)*<a name="attr-expression-condition-policy_bindings"></a>
 

--- a/test/testdata/markdown-structure.md
+++ b/test/testdata/markdown-structure.md
@@ -23,17 +23,17 @@ We can add infinite subsections!
 
   Default is `[]`.
 
-  Each object in the list accepts the following attributes:
+  Each `test_object` object in the list accepts the following attributes:
 
   - [**`name`**](#attr-name-test_objects): *(Optional `string`)*<a name="attr-name-test_objects"></a>
 
     A string
 
-  - [**`something_complex`**](#attr-something_complex-test_objects): *(Optional `any`)*<a name="attr-something_complex-test_objects"></a>
+  - [**`something_complex`**](#attr-something_complex-test_objects): *(Optional `object(nested_object)`)*<a name="attr-something_complex-test_objects"></a>
 
     Some other object
 
-    The object accepts the following attributes:
+    The `nested_object` object accepts the following attributes:
 
     - [**`nested_string`**](#attr-nested_string-something_complex-test_objects): *(Optional `string`)*<a name="attr-nested_string-something_complex-test_objects"></a>
 

--- a/test/testdata/parser-input.tfdoc.hcl
+++ b/test/testdata/parser-input.tfdoc.hcl
@@ -19,10 +19,15 @@ END
     section {
       title = "example"
 
-      variable "name" {
-        type        = string
-        description = "describes the name of the last person who bothered to change this file"
-        default     = "nathan"
+      variable "person" {
+        type = object(person)
+        description = "describes the last person who bothered to change this file"
+
+        attribute "name" {
+          type        = string
+          description = "the person's name"
+          default     = "nathan"
+        }
       }
     }
 
@@ -31,8 +36,7 @@ END
       content = "an excuse to mention alcohol"
 
       variable "beers" {
-        type        = list(any)
-        readme_type = "list(beer)"
+        type        = list(beer)
 
         description = "a list of beers"
         default     = []
@@ -47,6 +51,10 @@ beers = [
     name = "guinness"
     type = "stout"
     abv  = 4.2
+    tags = [
+      "dark",
+      "irish",
+    ]
   }
 ]
 END
@@ -71,6 +79,14 @@ END
           description = "beer's alcohol by volume content"
 
           forces_recreation = true
+        }
+
+        attribute "tags" {
+          type = list(string)
+
+          description = "a list of tags for the beer"
+
+          default = []
         }
       }
     }


### PR DESCRIPTION
to have a better user experience, we decided to consolidate the variable and attribute type setting. 
with this change, the `type` attribute have the same behavior as the `readme_type` attribute, with the exception that the later was given as a string and the former as a type expression.


now, to define the type of a variable or attribute, we can provide the following values:

```hcl
// primary types
variable "number" {
  type = number
}

variable "string" {
  type = string
}

variable "bool" {
  type = bool
}

// complex types
/// object type
variable "object" {
  type = object(a_label_for_the_object)
}

/// collection types
variable "list_of_strings" {
  type = list(string)
}

variable "list_of_objects" {
  type = list(a_label_for_the_nested_objects)
}

variable "set_of_numbers" {
  type = set(number)
}

variable "set_of_objects" {
  type = set(a_label_for_the_nested_objects)
}
```

this way, for an input file


```hcl
section {
  variable "object" {
    type = object(some_object)

    attribute "nested_object_field" {
      type = string
    }
  }

  /// collection types
  variable "list_of_strings" {
    type = list(string)
  }

  variable "list_of_objects" {
    type = list(another_object)

    attribute "nested_object_field" {
      type = string
    }
  }

  variable "set_of_numbers" {
    type = set(number)
  }

  variable "set_of_objects" {
    type = set(even_another_object)

    attribute "nested_object_field" {
      type = string
    }
  }
}

```

the result markdown will be:

```markdown
- [**`object`**](#var-object): *(Optional `object(some_object)`)*<a name="var-object"></a>

  The `some_object` object accepts the following attributes:

  - [**`nested_object_field`**](#attr-nested_object_field-object): *(Optional `string`)*<a name="attr-nested_object_field-object"></a>

- [**`list_of_strings`**](#var-list_of_strings): *(Optional `list(string)`)*<a name="var-list_of_strings"></a>

- [**`list_of_objects`**](#var-list_of_objects): *(Optional `list(another_object)`)*<a name="var-list_of_objects"></a>

  Each `another_object` object in the list accepts the following attributes:

  - [**`nested_object_field`**](#attr-nested_object_field-list_of_objects): *(Optional `string`)*<a name="attr-nested_object_field-list_of_objects"></a>

- [**`set_of_numbers`**](#var-set_of_numbers): *(Optional `set(number)`)*<a name="var-set_of_numbers"></a>

- [**`set_of_objects`**](#var-set_of_objects): *(Optional `set(even_another_object)`)*<a name="var-set_of_objects"></a>

  Each `even_another_object` object in the set accepts the following attributes:

  - [**`nested_object_field`**](#attr-nested_object_field-set_of_objects): *(Optional `string`)*<a name="attr-nested_object_field-set_of_objects"></a>
```


**if both `type` and `readme_type` are defined for a variable or attribute, `readme_type` gets precedence***